### PR TITLE
add function to make signed url

### DIFF
--- a/server.js
+++ b/server.js
@@ -102,7 +102,7 @@ function getSignedUrlForGCPFile(gcpFileObject) {
       expires: expDate,
   }
 
-  var signedUrl = gcpFileObject.getSignedUrl(config, function(err, url) {
+  gcpFileObject.getSignedUrl(config, function(err, url) {
     if (err) {
       console.error(err);
       return;

--- a/server.js
+++ b/server.js
@@ -83,6 +83,36 @@ function timeStamp() {
   return DateString;
 }
 
+function getSignedUrlForGCPFile(gcpFileObject) {
+  /*
+  Takes a gcp file object and applies a static config to create a signed url.
+  Inputs:
+    gcpFileObject - an instance of  https://cloud.google.com/nodejs/docs/reference/storage/1.6.x/File
+  Returns:
+    A signed url https://cloud.google.com/nodejs/docs/reference/storage/1.6.x/File#getSignedUrl
+    or an error
+  */
+
+  // Set a date two days in a future
+  var expDate = new Date();
+  expDate.setDate(expDate.getDate() + 2);
+
+  var config = {
+      action: 'read',
+      expires: expDate,
+  }
+
+  var signedUrl = gcpFileObject.getSignedUrl(config, function(err, url) {
+    if (err) {
+      console.error(err);
+      return;
+    };
+
+    let pleaLetterUrl = 'http://storage.googleapis.com/' + url;
+    return pleaLetterUrl;
+  });
+}
+
 router.route('/voter/:voter_id/letter')
   .get(function(req, res) {
     var timestamp = timeStamp();


### PR DESCRIPTION
### What?

Make a signed url for the gcp file object 

### Testing
tested on dev.  
        
take this code block
```
storage
          .bucket(bucketName)
          .upload(response.filename, uploadOptions)
          .then(() => {
```
and change then to ` .then((response) => {`
and in that block add
```
var gcpFile = response[0];
getSignedUrlForGCPFile(gcpFile);
```
and any console logging you want to see the signed url

also tested I can download and it doesnt break your server

### risk:
very low.  this function is not called yet in prod so it wont impact anything.  