### PR TITLE
Ratelimiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2968,6 +2968,14 @@
         "strip-bom": "2.0.0"
       }
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "1.0.3"
+      }
+    },
     "define-properties": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
@@ -4056,6 +4064,14 @@
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         }
+      }
+    },
+    "express-rate-limit": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-2.11.0.tgz",
+      "integrity": "sha512-KMZayDxj3Wr7zYuwTuDZj5hMW0nhnyJVBVCwMEVKwMdW6CkYh4vnfnUbRJYhKC0v6UuIbPerwKY0dqWmEzFjKA==",
+      "requires": {
+        "defaults": "1.0.3"
       }
     },
     "extend": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "csv-parse": "^2.1.0",
     "env": "0.0.2",
     "express": "^4.16.3",
+    "express-rate-limit": "^2.11.0",
     "file-saver": "^1.3.4",
     "foreman": "^2.0.0",
     "handlebars": "^4.0.11",

--- a/rateLimits.js
+++ b/rateLimits.js
@@ -2,8 +2,8 @@ var RateLimit = require('express-rate-limit'); //https://www.npmjs.com/package/e
 
 var makePledgeRateLimit = new RateLimit({
   windowMs: 60*60*1000, // 1 hour window
-  delayAfter: 0, // begin slowing down responses after the first request
-  delayMs: 0, // slow down subsequent responses by 1 seconds per request
+  delayAfter: 0, // no delay
+  delayMs: 0, // no delay
   max: 10, // start blocking after 10 requests
   message: "Too many pledge attemps made from right now.  Please try again later.",
 });

--- a/rateLimits.js
+++ b/rateLimits.js
@@ -1,0 +1,13 @@
+var RateLimit = require('express-rate-limit'); //https://www.npmjs.com/package/express-rate-limit
+
+var makePledgeRateLimit = new RateLimit({
+  windowMs: 60*60*1000, // 1 hour window
+  delayAfter: 0, // begin slowing down responses after the first request
+  delayMs: 0, // slow down subsequent responses by 1 seconds per request
+  max: 10, // start blocking after 10 requests
+  message: "Too many pledge attemps made from right now.  Please try again later.",
+});
+
+module.exports = {
+  makePledgeRateLimit,
+}

--- a/server.js
+++ b/server.js
@@ -34,8 +34,6 @@ app.use(cors(corsOption));
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
-
-
 router.get('/', function(req, res) {
   res.json('API initialized.');
 });
@@ -70,13 +68,8 @@ router.route('/voter/confirm-send')
     });
   });
 
-function tester (req, res, next) {
-  console.log('if you see this you were not rate limited');
-  next()
-}
-
 router.route('/voter/pledge')
-  .post(rateLimits.makePledgeRateLimit, tester, function(req, res) {
+  .post(rateLimits.makePledgeRateLimit, function(req, res) {
     voterService.makePledge(req.body.code, function(result) {
       res.json(result);
     });

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ var Handlebars = require('handlebars');
 var Hashids = require('hashids');
 var uuidv4 = require('uuid/v4');
 
+var rateLimits = require('./ratelimits')
 var voterService = require('./voterService');
 var db = require('./src/db');
 var fs = require('fs');
@@ -32,6 +33,8 @@ var hashids = new Hashids(process.env.REACT_APP_HASHID_SALT, 6,
 app.use(cors(corsOption));
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
+
+
 
 router.get('/', function(req, res) {
   res.json('API initialized.');
@@ -67,8 +70,13 @@ router.route('/voter/confirm-send')
     });
   });
 
+function tester (req, res, next) {
+  console.log('if you see this you were not rate limited');
+  next()
+}
+
 router.route('/voter/pledge')
-  .post(function(req, res) {
+  .post(rateLimits.makePledgeRateLimit, tester, function(req, res) {
     voterService.makePledge(req.body.code, function(result) {
       res.json(result);
     });


### PR DESCRIPTION
### What
Rate limit pledges so people cant ruin your db

I put it in its own file so one could easily add more rate limits in the future/keep server.js from becoming a monster file.  Just define a `new RateLimit` object, export it, and then use it in server JS as a express router middleware prior to the function that handles a legit request.  Express middleware is neat, I havent worked with it before but seems very nice and handy.

### testing
1.  open app and pledge page
2.  open chrome dev console and go to sources tab
3.  Click the make pledge button 11 times with some text in it
See 429 too many requests in the response

![screen shot 2018-04-01 at 10 06 51 pm](https://user-images.githubusercontent.com/1569764/38183953-20b68fbc-35f9-11e8-97a5-65301626c958.png)

### risks
Low risk. 
1.  If rate limit it too strict it could stop people from pledging
2.  If lots of people have the same IP for some reason (dorms, apt complex maybe, or weird ISP shiz) AND they all tried to pledge in the same time peroid they might get rate limited (seems unlikely)

### Caveats
As per their docs this only works on a single server architecture since it uses the node local memory. 
https://github.com/nfriedly/express-rate-limit

This is probably fine for MVP if you are just running on one host. Even if you had a few hosts it would probably be fine, but each host would have its own rate limit (so a rate limit of ten on 2 hosts would at most allow up to 20 requests assuming they get distributed evenly)

Scaling this up doesnt look horrible either.  Their are other node libs for using something like memcache or redis to store the ip and limit and check in a distributed fashion.  
