### PR TITLE
Fixes render bug with qualification steps on dashboard.

### DIFF
--- a/server.js
+++ b/server.js
@@ -104,7 +104,7 @@ router.route('/user')
       .then(function(result) {
         res.json(result)
       })
-    .catch(err => {console.error(err);})
+      .catch(err => {console.error(err);})
   })
   .post(function(req, res) {
     let query = db('users')

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -14,7 +14,39 @@ class Dashboard extends Component {
 
     this.handleAdoptedVoter = this.handleAdoptedVoter.bind(this);
     this.handleConfirmSend = this.handleConfirmSend.bind(this);
-    this.state = { voters: [] }
+    this.state = { voters: [], user: {}, isQualified: true }
+  }
+
+  getUser() {
+    let user_id = localStorage.getItem('user_id');
+    axios.get(`${process.env.REACT_APP_API_URL}/user`,
+      {
+        params: { auth0_id: user_id }
+      })
+      .then(res => {
+        this.setState({ user: res.data[0] }, () => {
+          this.isUserQualified();
+        })
+      })
+      .catch(err => {
+        console.error(err)
+      });
+  }
+
+  isUserQualified() {
+    if (
+        this.state.user.is_human_at &&
+        this.state.user.accepted_code_at &&
+        this.state.user.is_resident_at &&
+        this.state.user.zip &&
+        this.state.user.full_name
+      )
+    {
+      this.setState({ isQualified: true })
+    }
+    else {
+      this.setState({ isQualified: false })
+    }
   }
 
   getAdoptedVoters() {
@@ -60,7 +92,8 @@ class Dashboard extends Component {
   }
 
   componentWillMount(){
-    this.getAdoptedVoters()
+    this.getUser();
+    this.getAdoptedVoters();
   }
 
   render() {
@@ -69,7 +102,7 @@ class Dashboard extends Component {
         <Header />
         { this.props.auth.isAuthenticated() ? (
           <div>
-            <Qualify />
+            <Qualify isQualified={this.state.isQualified} user={this.state.user} />
             <Login auth={this.props.auth} />
             <AdoptVoter handleAdoptedVoter={this.handleAdoptedVoter}/>
             <VoterList voters={this.state.voters} confirmSend={this.handleConfirmSend}/>

--- a/src/Qualify.js
+++ b/src/Qualify.js
@@ -8,7 +8,6 @@ export class Qualify extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      user: {},
       isHuman: false,
       isResident: false,
       agreedCode: false,
@@ -76,44 +75,21 @@ export class Qualify extends Component {
     });
   }
 
-  componentWillMount() {
-    let userId = localStorage.getItem('user_id');
-    axios({
-      method: 'GET',
-      url: `${process.env.REACT_APP_API_URL}/user`,
-      params: { auth0_id: userId }
-    })
-    .then(res => {
-      this.setState({user: res.data[0]}, () => {
-        this.setState({
-          isHuman: this.state.user.is_human_at,
-          isResident: this.state.user.is_resident_at,
-          agreedCode: this.state.user.accepted_code_at,
-          zip: this.state.user.zip,
-          fullName: this.state.user.full_name
-        })
-      });
-    })
-    .catch(err => {
-      console.error(err);
-    });
-  }
-
-  isQualified() {
-    if ( this.state.isHuman &&
-      this.state.agreedCode &&
-      this.state.isResident &&
-      this.state.zip &&
-      this.state.fullName
-    ) {
-      return true
-    }
-    else {
-      return false
+  componentWillReceiveProps(nextProps) {
+    let user = nextProps.user;
+    if (user) {
+      this.setState({
+        isHuman: user.is_human_at,
+        isResident: user.is_resident_at,
+        agreedCode: user.accepted_code_at,
+        zip: user.zip,
+        fullName: user.full_name
+      })
     }
   }
 
   render() {
+
     let formMarkup;
 
     let captchaQ = (
@@ -142,7 +118,7 @@ export class Qualify extends Component {
         <label className="mr2">Yes.</label>
         <input className="ph2 " onClick={this.handleIsResident.bind(this)} type="checkbox" />
       </div>
-    )
+    );
 
     let zipQ = (
       <form onSubmit={this.handleZipSubmit}>
@@ -153,7 +129,7 @@ export class Qualify extends Component {
         />
         <input type="submit" value="Submit" />
       </form>
-    )
+    );
 
     let codeQ = (
       <div>
@@ -162,7 +138,7 @@ export class Qualify extends Component {
         <label className="mr2">Yes.</label>
         <input className="ph2" onClick={this.handleAgreedCode.bind(this)} type="checkbox" />
       </div>
-    )
+    );
 
     if (!this.state.isHuman) {
       formMarkup = captchaQ;
@@ -183,7 +159,7 @@ export class Qualify extends Component {
       formMarkup = null;
     }
 
-    if (!this.isQualified()) {
+    if (!this.props.isQualified && formMarkup) {
       return (
         <div className="w-50 center">
           <p>First, we need to make sure of a few things...</p>

--- a/voterService.js
+++ b/voterService.js
@@ -43,7 +43,6 @@ function adoptRandomVoter(adopterId, callback) {
           updated_at: db.fn.now()
         })
         .then(function() {
-          console.log('Voter id: ' + voter.id);
           letterService.generatePdfForVoter(voter, function(signedUrl) {
               callback(voter, signedUrl);
             });


### PR DESCRIPTION
I moved the check for full "qualification" (i.e., having accepted all the requisite things and given name and ZIP) to the Dashboard component, parent of the Qualify component. 

By setting isQualified to "true" by default in Dashboard, and passing that state down as a prop to Qualify, this change makes the qualification wizard appear only once it's explicitly told by Dashboard that it's necessary to do so. 