### PR TITLE
Secures all the routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -70,7 +70,7 @@ router.route('/voters')
   });
 
 router.route('/voter/adopt-random')
-  .post(function(req, res) {
+  .post(checkJwt, function(req, res) {
     voterService.adoptRandomVoter(req.body.adopterId, req.body.numVoters, function(voters) {
       let response = {};
       response.voters = voters;
@@ -79,7 +79,7 @@ router.route('/voter/adopt-random')
   });
 
 router.route('/voter/confirm-send')
-  .put(function(req, res) {
+  .put(checkJwt, function(req, res) {
     voterService.confirmSend(req.body.id, function(result) {
       res.json(result);
     });
@@ -93,14 +93,14 @@ router.route('/voter/pledge')
   });
 
 router.route('/voter/signed-letter-url')
-  .get(function(req, res) {
+  .get(checkJwt, function(req, res) {
     letterService.getSignedUrl(req.query.url, function(result) {
       res.json(result);
     });
   });
 
 router.route('/user/new')
-  .post(function(req, res) {
+  .post(checkJwt, function(req, res) {
     if (req.body.auth0_id) {
       db('users').where('auth0_id', req.body.auth0_id)
         .then(function(result) {
@@ -142,7 +142,7 @@ function verifyHumanity(req, callback) {
 }
 
 router.route('/recaptcha')
-  .post(function(req, res) {
+  .post(checkJwt, function(req, res) {
     verifyHumanity(req, function(r) {
       if(r) {
         res.json(r);
@@ -156,7 +156,7 @@ router.route('/recaptcha')
   });
 
 router.route('/user')
-  .get(function(req, res) {
+  .get(checkJwt, function(req, res) {
     db('users')
       .where('auth0_id', req.query.auth0_id)
       .then(function(result) {
@@ -164,7 +164,7 @@ router.route('/user')
       })
       .catch(err => {console.error(err);})
   })
-  .post(function(req, res) {
+  .post(checkJwt, function(req, res) {
     let query = db('users')
       .where('auth0_id', req.body.auth0_id)
       .update('updated_at', db.fn.now())

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -29,6 +29,7 @@ class UserListItem extends Component {
   getVoters() {
     axios({
       method: 'GET',
+      headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
       url: `${process.env.REACT_APP_API_URL}/voters`,
       params: { user_id: this.props.user.auth0_id }
     })
@@ -70,6 +71,7 @@ class Admin extends Component {
     let user_id = localStorage.getItem('user_id');
     if (user_id) {
       axios({
+        headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
         method: 'GET',
         url: `${process.env.REACT_APP_API_URL}/user`,
         params: { auth0_id: user_id }
@@ -90,6 +92,7 @@ class Admin extends Component {
   getAllUsers() {
     axios({
       method: 'GET',
+      headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
       url: `${process.env.REACT_APP_API_URL}/s/users`,
     })
     .then(res => {

--- a/src/AdoptVoter.js
+++ b/src/AdoptVoter.js
@@ -15,6 +15,7 @@ export class AdoptVoter extends Component {
     this.setState({adopting: true});
     let user_id = localStorage.getItem('user_id');
     axios({
+      headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
       method: 'POST',
       url: `${process.env.REACT_APP_API_URL}/voter/adopt-random`,
       data: {

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -36,12 +36,18 @@ export default class Auth {
   }
 
   persistUser(authResult, callback) {
-    axios.post(`${process.env.REACT_APP_API_URL}/user/new`,
-      { auth0_id: authResult.idTokenPayload.sub })
+    axios({
+      method: 'POST',
+      headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
+      url: `${process.env.REACT_APP_API_URL}/user/new`,
+      data: {
+        auth0_id: authResult.idTokenPayload.sub 
+      }
+    })
     .then(callback)
     .catch(function(error) {
       console.error(error)
-    });
+    })
   }
 
   setSession(authResult) {

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -21,9 +21,11 @@ class Dashboard extends Component {
   getCurrentUser() {
     let user_id = localStorage.getItem('user_id');
     if (user_id) {
-      axios.get(`${process.env.REACT_APP_API_URL}/user`,
-        {
-          params: { auth0_id: user_id }
+      axios({
+        method: 'GET',
+        headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
+        url: `${process.env.REACT_APP_API_URL}/user`,
+        params: { auth0_id: user_id }
         })
         .then(res => {
           this.setState({ user: res.data[0] }, () => {
@@ -87,6 +89,7 @@ class Dashboard extends Component {
   handleConfirmSend(voter) {
     axios({
       method: 'PUT',
+      headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
       url: `${process.env.REACT_APP_API_URL}/voter/confirm-send`,
       data: { id: voter.id }
       })

--- a/src/Qualify.js
+++ b/src/Qualify.js
@@ -27,6 +27,7 @@ export class Qualify extends Component {
   handleCaptcha(response) {
     axios({
       method: 'POST',
+      headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
       url: `${process.env.REACT_APP_API_URL}/recaptcha`,
       data: {
         recaptchaResponse: response
@@ -84,6 +85,7 @@ export class Qualify extends Component {
     data[key] = value;
     axios({
       method: 'POST',
+      headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
       url: `${process.env.REACT_APP_API_URL}/user`,
       data: data
     })

--- a/src/VoterList.js
+++ b/src/VoterList.js
@@ -14,6 +14,7 @@ class VoterRecord extends Component {
 
   getSignedUrl(rawUrl) {
     axios({
+      headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
       method: 'GET',
       url: `${process.env.REACT_APP_API_URL}/voter/signed-letter-url`,
       params: { url: rawUrl }


### PR DESCRIPTION
This follows on https://github.com/sjforman/votefwd/pull/20 and adds the `checkJwt` middleware to all the other routes besides the one that @andrewjtimmons added it to for demonstration / testing purposes.

Tested locally by adding the middleware to each route, exercising the functionality that calls that route to see it fail with an "unauthorized" error, then adding the `Authorization` header, then exercising the functionality again to see it succeed. 

I think this is pretty safe. Merging. 