### PR TITLE
Fix bulk download bug

### DIFF
--- a/letterService.js
+++ b/letterService.js
@@ -147,7 +147,7 @@ function generatePdfFromBulkHtml(html, callback) {
   const remotefileName = datestamp + '-' + uuid + '-letter.pdf'
   const downloadFileName = datestamp + '-' + uuid + '-VoteForward-letter.pdf';
   const filePath = tmpdir + '/' + remotefileName;
-  pdf.create(html).toFile(filePath, function(err, response){
+  pdf.create(html, {timeout: '100000'}).toFile(filePath, function(err, response){
     if(err) {
       console.error('ERROR:', err);
     }

--- a/templates/coverpage.html
+++ b/templates/coverpage.html
@@ -4,14 +4,11 @@
     <meta charset="UTF-8">
     <link href="https://fonts.googleapis.com/css?family=Merriweather+Sans" rel="stylesheet">
     <style>
-      body { font-family: 'Merriweather Sans', sans-serif; margin-top: 2em; margin-left: 3em; margin-right: 3em;}
-      svg { width:16em; height:8em; margin-left:-3em; }
-      ul { font-size: .7em; }
+      body { font-family: 'Merriweather Sans', sans-serif; margin-top: 3em; margin-left: 1em; margin-right: 1em; }
+      svg { width: 10em; height: 5em; margin-left:-3em; }
+      ul { font-size: 0.7em; }
       li { list-style-type: none;  margin-left:-3em; margin-bottom: 0.2em; }
-      .bold { font-weight: bold;}
       .pagebreak { page-break-after: always; }
-      #salutation {margin-bottom: 2em;}
-      #return-address { float: right; }
     </style>
     <title>Voter Letters Cover Page</title>
   </head>
@@ -29,8 +26,10 @@
             </g>
         </g>
     </svg>
-    <p id="return-address">Return address for envelopes: <br/><br/>{your initials} </br>829 Bethel Rd. #137 </br> Columbus, OH 43214</p>
-    <p id="salutation">Here’s a list of all the voters in this bulk download. Thanks for writing letters to help flip Congress blue!</p>
+    <p>Thank you for writing letters to flip Congress blue!</p>
+    <p>Return address for envelopes:</p>
+    <p>{your initials} </br>829 Bethel Rd. #137 </br> Columbus, OH 43214</p>
+    <p>{{voters.length}} voters in this bulk download:</p>
     <ul>
       {{#each voters}}
       <li>

--- a/voterService.js
+++ b/voterService.js
@@ -74,7 +74,7 @@ function adoptRandomVoter(adopterId, numVoters, callback) {
 function downloadAllLetters(userId, callback) {
   db('voters')
     .where('adopter_user_id', userId)
-    .where('confirmed_sent_at', null)
+    .where('confirmed_prepped_at', null)
     .then(function(voters) {
       letterService.generateBulkPdfForVoters(voters, callback)
     })


### PR DESCRIPTION
Bulk download has still been failing on prod. https://github.com/marcbachmann/node-html-pdf/issues/222#issuecomment-379263068 suggests that increasing the timeout to a large value might help. This PR adds that change to bulk generation, and fixes another bug wherein all unsent letters rather than all unprepped letters were being downloaded. Also some minor changes to the cover page template.