### PR TITLE
Uncomments the conditional failure in recaptcha route.

### DIFF
--- a/server.js
+++ b/server.js
@@ -177,16 +177,14 @@ function verifyHumanity(req, callback) {
 router.route('/recaptcha')
   .post(checkJwt, function(req, res) {
     verifyHumanity(req, function(r) {
-      res.json(true);
-      // TODO: MAKE THIS ACTUALLY WORK! CURRENTLY ALWAYS TRUE FOR ALPHA TESTING
-      //if(r) {
-        //res.json(r);
-      //} else {
-        //res.status(400);
-        //res.send({
-          //error: 'Please verify that you\'re human'
-        //})
-      //}
+      if(r) {
+        res.json(r);
+      } else {
+        res.status(400);
+        res.send({
+          error: 'Please verify that you\'re human'
+        })
+      }
     });
   });
 

--- a/src/Qualify.js
+++ b/src/Qualify.js
@@ -79,7 +79,7 @@ export class Qualify extends Component {
       <div>
         <p>Are you a robot?</p>
         <div className="mb-3">
-          <RecaptchaComponent handleSuccess={this.handleCaptcha.bind(this)}/>
+          <RecaptchaComponent handleCaptchaResponse={this.handleCaptcha.bind(this)}/>
         </div>
         <ProgressIndicator current={0} max={6}></ProgressIndicator>
       </div>

--- a/src/Recaptcha.js
+++ b/src/Recaptcha.js
@@ -10,7 +10,7 @@ export class RecaptchaComponent extends React.Component {
       <ReCAPTCHA
         ref="recaptcha"
         sitekey={process.env.REACT_APP_RECAPTCHA_SITE_KEY}
-        onChange={this.props.handleSuccess}
+        onChange={this.props.handleCaptchaResponse}
       />
     );
   }


### PR DESCRIPTION
Last weekend I commented out the code that would return a `400` if reCaptcha fails, because it was mucking things up as I was trying to get the alpha launched. This still works locally, and I'm not sure if it will work on deployed environment, but I'm going to try it again and debug more carefully if it continues to cause more problems. 