### PR TITLE
District page

### DIFF
--- a/migrations/20180916165655_add_district_index_to_voters.js
+++ b/migrations/20180916165655_add_district_index_to_voters.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table('voters', function(table) {
+    table.index('district_id');
+  })
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table('voters', function(table) {
+    table.dropIndex('district_id');
+  })
+};

--- a/migrations/20180916170019_add_district_index_to_users.js
+++ b/migrations/20180916170019_add_district_index_to_users.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table('users', function(table) {
+    table.index('current_district');
+  })
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table('users', function(table) {
+    table.dropIndex('current_district');
+  })
+};

--- a/server/rateLimits.js
+++ b/server/rateLimits.js
@@ -8,6 +8,15 @@ var makePledgeRateLimit = new RateLimit({
   message: "Too many pledge attemps made from right now.  Please try again later.",
 });
 
+var lookupDistrictRateLimit = new RateLimit({
+  windowMs: 60*1000, // 1 minute window
+  delayAfter: 0, // no delay
+  delayMs: 0, // no delay
+  max: 10, // start blocking after 10 requests
+  message: "Too many district lookup attemps made from right now.  Please try again later.",
+});
+
 module.exports = {
   makePledgeRateLimit,
+  lookupDistrictRateLimit,
 }

--- a/server/server.js
+++ b/server/server.js
@@ -439,8 +439,6 @@ router.route('/lookup-district')
         })
         .catch(err => {console.error(err);})
     }
-
-
   });
 
 /**

--- a/server/server.js
+++ b/server/server.js
@@ -377,7 +377,17 @@ router.route('/lookup-district')
         voters_agg.voters_adopted,
         voters_agg.letters_prepped,
         voters_agg.letters_sent,
-        districts.*
+        districts.district_id,
+        districts.state,
+        districts.state_abbr,
+        districts.district_num,
+        districts.description,
+        districts.lat,
+        districts.long,
+        districts.return_address,
+        districts.ra_city,
+        districts.ra_state,
+        districts.ra_zip
         from districts
         left join users
         on districts.district_id = users.current_district
@@ -416,7 +426,7 @@ router.route('/lookup-district')
         ) voters_agg
         on districts.district_id = voters_agg.district_id
         where districts.district_id = ?
-        group by 2,3,4,5,6;`,
+        group by voters_agg.voters_available, voters_agg.voters_adopted, voters_agg.letters_prepped, voters_agg.letters_sent, districts.district_id, districts.state, districts.state_abbr, districts.district_num, districts.description, districts.lat, districts.long, districts.return_address, districts.ra_city, districts.ra_state, districts.ra_zip;`,
         [req.query.district_id, req.query.district_id]
         )
       .then(function(result) {

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -73,7 +73,10 @@ class Dashboard extends Component {
         method: 'GET',
         headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
         url: `${process.env.REACT_APP_API_URL}/lookup-district`,
-        params: {district_id: districtId }
+        params: {
+          district_id: districtId,
+          get_adoption_details: true
+          }
         })
         .then(res => {
           if (res.data.length === 0) {


### PR DESCRIPTION
what?
return stats on number users, voters and letters for a district if the param `get_adoption_details: true` is set for lookup-district

sample response
```
[{"num_users_using_district":"1","voters_available":"10","voters_adopted":"0","letters_prepped":"0","letters_sent":"0","id":1,"district_id":"AZ02","state":"Arizona","state_abbr":"AZ","district_num":"02","description":"WORDSWORDSWORDS","lat":32.61,"long":-110.48,"coordinates":{"x":32.61,"y":-110.48},"return_address":"1517 N Wilmot Rd #121","ra_city":"Tucson","ra_state":"AZ","ra_zip":"85712"}]
```

testing:
tested in postgres and on dev.  Changed the api call for looking up a district in dashboard.js to be 
```
       url: `${process.env.REACT_APP_API_URL}/lookup-district`,
        params: {
          district_id: districtId,
          get_adoption_details: true
          }
```
and looked at the response in the browser

Also checked that knex escapes these parameters https://knexjs.org/#Raw and it does

Also tested rate limits and they work.

risks:
low risk
1.  this makes the district info api not require auth.  it is now rate limited to 10 calls per minute
2.  this makes us run a multi table join.  if perf gets bad it could be bad. probably fine.

future tech debt thoughts
this might be better as separate functions, but callback and promise changing heck made us go this way.  