### PR TITLE
Moving targeting to node

### DIFF
--- a/bin/targeting.js
+++ b/bin/targeting.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var db = require('../server/db');
+
+var voters = db.select().table('voters')
+  .then(function(result) {
+    return result;
+    });
+
+console.log(voters.length);
+
+function updateVoterSuffix(dwid) {
+  db('voters')
+    .where('registration_id', dwid)
+    .update({
+      suffix: 'JR'
+    })
+    .catch(err => {
+      console.error(err);
+    });
+}
+
+updateVoterSuffix(9912895);

--- a/bin/targeting.js
+++ b/bin/targeting.js
@@ -5,19 +5,78 @@ var db = require('../server/db');
 var voters = db.select().table('voters')
   .then(function(result) {
     return result;
-    });
+  });
 
-console.log(voters.length);
+//console.log(voters.length);
 
 function updateVoterSuffix(dwid) {
   db('voters')
     .where('registration_id', dwid)
     .update({
-      suffix: 'JR'
+      suffix: 'JRs'
     })
     .catch(err => {
       console.error(err);
     });
 }
 
+// Fisher–Yates Shuffle.
+// Author: Mike Bostock
+function shuffle(array) {
+  var m = array.length, t, i;
+
+  // While there remain elements to shuffle…
+  while (m) {
+
+    // Pick a remaining element…
+    i = Math.floor(Math.random() * m--);
+
+    // And swap it with the current element.
+    t = array[m];
+    array[m] = array[i];
+    array[i] = t;
+  }
+
+  return array;
+}
+
 updateVoterSuffix(9912895);
+
+function sampleExample() {
+	var x = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
+	console.log(x)
+	shuffle(x)
+	console.log(x)
+
+	var sample = x.slice(0, 10);
+	console.log(sample)
+}
+
+// TODO: Write a new experiment.
+var Promise = require('bluebird');
+db.transaction(function(trx) {
+  console.log('Started transaction.')
+  var ids = db('experiment')
+      .transacting(trx)
+      .insert({name: 'CA10', description: 'Propensity 5-75, Dem partizanship > 90'})
+      .then(function(response) {
+        console.log("Response:", response);
+      })
+      .then(trx.commit)
+      .catch(trx.rollback);
+})
+.then(function(resp) {
+  console.log('Transaction complete.');
+})
+.catch(function(err) {
+  console.error(err);
+});
+
+
+// TODO: Write to experiment_voter all catalyst_raw voters based on state and district,
+// which are not already in experiment_voter (can have duplicates).
+// TODO: Log the number of experiment_voter records where cohort is null.
+// TODO: Set all to control where cohort is null.
+// TODO: Set to TARGET for randomly selected voters in experiment_voter based on experiment_id.
+// TODO: Add all new TREATMENT (TEST) experiment_voters to voters table.
+

--- a/bin/targeting.js
+++ b/bin/targeting.js
@@ -2,24 +2,6 @@
 
 var db = require('../server/db');
 
-var voters = db.select().table('voters')
-  .then(function(result) {
-    return result;
-  });
-
-//console.log(voters.length);
-
-function updateVoterSuffix(dwid) {
-  db('voters')
-    .where('registration_id', dwid)
-    .update({
-      suffix: 'JRs'
-    })
-    .catch(err => {
-      console.error(err);
-    });
-}
-
 // Fisher–Yates Shuffle.
 // Author: Mike Bostock
 function shuffle(array) {
@@ -38,18 +20,6 @@ function shuffle(array) {
   }
 
   return array;
-}
-
-updateVoterSuffix(9912895);
-
-function sampleExample() {
-	var x = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
-	console.log(x)
-	shuffle(x)
-	console.log(x)
-
-	var sample = x.slice(0, 10);
-	console.log(sample)
 }
 
 var STATE = 'MN'
@@ -80,9 +50,10 @@ var del_resp = db('experiment_voter').delete().then(function(){
         var experiment_id = ids[0];
         // Find all voters from the district which are not yet part of an experiment. Note that
         // in rare cases, a single voter might be in multiple districts.
-        db.raw("select dwid from catalist_raw left join experiment_voter on catalist_raw.dwid = experiment_voter.voter_id where experiment_voter.voter_id is NULL and catalist_raw.state='MN' and catalist_raw.congressional_district='2' order by RANDOM()")
+        db.raw("select dwid from catalist_raw left join experiment_voter on catalist_raw.dwid = experiment_voter.voter_id where experiment_voter.voter_id is NULL and catalist_raw.state='MN' and catalist_raw.congressional_district='2'")
           .then(function(dwiws_result) {
             var dwiws = dwiws_result.rows;
+            shuffle(dwiws);
             console.log('Found ' + dwiws.length + ' unassigned dwiw.');
             var num_test = dwiws.length - NUMBER_OF_CONTROLS;
             console.log('Assigning ' + num_test + ' to TEST, and ' + NUMBER_OF_CONTROLS + ' to CONTROL.');
@@ -116,7 +87,6 @@ var del_resp = db('experiment_voter').delete().then(function(){
       console.error(err);
       process.exit(1);
     });
-
   });
 });
 

--- a/bin/targeting.js
+++ b/bin/targeting.js
@@ -25,68 +25,72 @@ function shuffle(array) {
 var STATE = 'MN'
 var DISTRICT = '2'
 var EXPERIMENT_DESCRIPTION = 'Propensity 5-75, Dem partizanship > 90'
-var NUMBER_OF_CONTROLS = 10000;
+var HOLDOUT = 0.1;  // Control = 10% of the total number of voters.
 
 var Promise = require('bluebird');
 
-// Delete all experiment, just for convenience while developing.
-// TODO: Remove this before actually running.
-var del_resp = db('experiment_voter').delete().then(function(){
-  db('experiment').delete().then(function() {
-    db.transaction(function(trx) {
-      console.log('Started transaction.')
-      // TODO(scott): Pad the district (or don't).
-      var ids_response = db('experiment')
-          .transacting(trx)
-          .insert({name: STATE + DISTRICT, description: EXPERIMENT_DESCRIPTION}, 'id')
-          .catch(function(error) {
-            console.log(error);
-            console.log('Error creating experiment.');
-            trx.rollback();
-            process.exit(1);
-          });
-      ids_response.then(function(ids) {
-        console.log("Registered experiment with ID: ", ids[0]);
-        var experiment_id = ids[0];
-        // Find all voters from the district which are not yet part of an experiment. Note that
-        // in rare cases, a single voter might be in multiple districts.
-        db.raw("select dwid from catalist_raw left join experiment_voter on catalist_raw.dwid = experiment_voter.voter_id where experiment_voter.voter_id is NULL and catalist_raw.state='MN' and catalist_raw.congressional_district='2'")
-          .then(function(dwiws_result) {
-            var dwiws = dwiws_result.rows;
-            shuffle(dwiws);
-            console.log('Found ' + dwiws.length + ' unassigned dwiw.');
-            var num_test = dwiws.length - NUMBER_OF_CONTROLS;
-            console.log('Assigning ' + num_test + ' to TEST, and ' + NUMBER_OF_CONTROLS + ' to CONTROL.');
-            var experiment_voters = dwiws.map(function (dwiw, index) {
-              var cohort = index <= num_test ? 'TEST' : 'CONTROL';
-              return {'experiment_id': experiment_id, 'voter_id': dwiw, 'cohort': cohort};
-            });
-            db('experiment_voter').transacting(trx).insert(experiment_voters).then(function() {
-              console.log('Inserted experiment voters.');
-              trx.commit();
-            })
-            .catch(function(err) {
-              console.error(err);
-              trx.rollback();
-              process.exit(1);
-            });
-          })
-          .catch(function(err) {
-            console.error(err);
-            trx.rollback();
-            process.exit(1);
-          });
+db.transaction(function(trx) {
+  console.log('Started transaction.')
+  // TODO(scott): Pad the district (or don't).
+  var ids_response = db('experiment')
+      .transacting(trx)
+      .insert({name: STATE + DISTRICT, description: EXPERIMENT_DESCRIPTION}, 'id')
+      .catch(function(error) {
+        console.log(error);
+        console.log('Error creating experiment.');
+        trx.rollback();
+        process.exit(1);
+      }).then(function(ids_response) {
+    var experiment_id = ids_response[0];
+    console.log("Registered experiment with ID: ", experiment_id);
+    // Find all voters from the district which are not yet part of an experiment. Note that
+    // in rare cases, a single voter might be in multiple districts.
+    db.raw(`select
+        dwid
+        from catalist_raw
+        left join experiment_voter
+        on catalist_raw.dwid = experiment_voter.voter_id
+        where
+          experiment_voter.voter_id is NULL
+        and catalist_raw.state = ?
+        and catalist_raw.congressional_district= ?`,
+        [STATE, DISTRICT])
+      .then(function(dwids_result) {
+        var dwids = dwids_result.rows;
+        shuffle(dwids);
+        console.log('Found ' + dwids.length + ' unassigned dwid.');
+        console.log('Assigning ' + HOLDOUT * 100 + '% to control.');
+        var num_controls = Math.floor(dwids.length * HOLDOUT);
+        var num_test = dwids.length - num_controls;
+        console.log('Assigning ' + num_test + ' to TEST, and ' + num_controls + ' to CONTROL.');
+        var experiment_voters = dwids.map(function (dwid, index) {
+          var cohort = index <= num_test ? 'TEST' : 'CONTROL';
+          return {'experiment_id': experiment_id, 'voter_id': dwid, 'cohort': cohort};
+        });
+        db('experiment_voter').transacting(trx).insert(experiment_voters).then(function() {
+          console.log('Inserted experiment voters.');
+          trx.commit();
+        })
+        .catch(function(err) {
+          console.error(err);
+          trx.rollback();
+          process.exit(1);
+        });
       })
-      .catch(trx.rollback);
-    })
-    .then(function(resp) {
-      console.log('Transaction complete.');
-      process.exit(0);
-    })
-    .catch(function(err) {
-      console.error(err);
-      process.exit(1);
-    });
-  });
+      .catch(function(err) {
+        console.error(err);
+        trx.rollback();
+        process.exit(1);
+      });
+  })
+  .catch(trx.rollback);
+})
+.then(function(resp) {
+  console.log('Transaction complete.');
+  process.exit(0);
+})
+.catch(function(err) {
+  console.error(err);
+  process.exit(1);
 });
 


### PR DESCRIPTION
Currently, voter targeting for TEST vs. CONTROL is managed in SQL scripts - one for each state and district. We'd like to move this into a node.js library so that it can more easily be tested and run (we expect to add 50+ districts. We'd also like to introduce stratified sampling downstream from this.

This PR introduces basic support for targeting.