### PR TITLE
Fix ipad pdf issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ variables:
 	REACT_APP_RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 	REACT_APP_RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 	REACT_APP_SLACK_WEBHOOK_URL=<LEAVEBLANK>
+	REACT_APP_JWT_SECRET=eXB62QzaWp54hrjHtyfYJVgwr5NJNZ5dCRf43wEj
 
 You might notice we have a REACT_APP_RECAPTCHA_SECRET but that is the [default google test one](https://developers.google.com/recaptcha/docs/faq), so this is not actually sensitive.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7372,15 +7372,6 @@
         "ms": "^2.1.1"
       },
       "dependencies": {
-        "jws": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-          "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
-          "requires": {
-            "jwa": "^1.1.5",
-            "safe-buffer": "^5.0.1"
-          }
-        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -7425,6 +7416,15 @@
         "lru-memoizer": "^1.6.0",
         "ms": "^2.0.0",
         "request": "^2.73.0"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "requires": {
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kdbush": {
@@ -7791,9 +7791,9 @@
       "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
     },
     "lru-cache": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "history": "^4.7.2",
     "html-pdf": "^2.2.0",
     "js-file-download": "^0.4.1",
+    "jsonwebtoken": "^8.3.0",
     "jwks-rsa": "^1.3.0",
     "knex": "^0.15.0",
     "mapbox-gl": "^0.49.0",

--- a/server/server.js
+++ b/server/server.js
@@ -65,12 +65,12 @@ router.get('/', function(req, res) {
 });
 
 router.route('/voters')
-  .get(checkJwt, function(req, res) {
-    voterService.getUsersAdoptedVoters(req.query.user_id,
-      function(result) {
-          res.json(result)
-      });
-  });
+.get(checkJwt, function(req, res) {
+  voterService.getUsersAdoptedVoters(req.query.user_id,
+    function(result) {
+      res.json(result)
+    });
+});
 
 router.route('/voter/adopt-random')
   .post(checkJwt, function(req, res) {
@@ -85,14 +85,17 @@ router.route('/voter/adopt-random')
       res.json(response);
     });
   });
-
-router.route('/voters/downloadLetter')
-  .get(checkJwt, function(req, res) {
-    voterService.downloadLetterToVoter(req.query.voter_id,
+/**
+ * If the JWT contains a "voterId" value, then this is a letter to a single voter.
+ * Otherwise it's a letter to all voters for that user.
+ */
+router.route('/letters/:letterJwt.pdf')
+  .get(function(req, res) {
+    voterService.downloadPdf(req.params.letterJwt,
       function(err, filepath, downloadFileName) {
         if (err) {
           res.status(500).send('Error generating file');
-          console.error('Error generating file for one voter');
+          console.error('Error generating file for voter(s)');
           console.error(err);
           return;
         }
@@ -100,36 +103,44 @@ router.route('/voters/downloadLetter')
         res.header('Filename', downloadFileName);
         res.download(filepath, downloadFileName, function (err) {
            if (err) {
-              console.log("Error downloading letter.");
+              console.log("Error downloading letter(s).");
               console.log(err);
            } else {
-              console.log("Success downloading letter.");
+              console.log("Success downloading letter(s).");
            }
         });
       });
   });
 
-router.route('/voters/downloadAllLetters')
+
+/**
+ * This route creates a secure url that can be used to download the pdf.  It 
+ * creates a one-minute-long JWT that gets included in the url 
+ * that contains either userId and voterId to download a single voter's pdf,
+ * or just the userId to download all voters for that user.
+ */
+router.route('/voters/letterUrl')
   .get(checkJwt, function(req, res) {
-    voterService.downloadAllLetters(req.query.user_id,
-      function(err, filepath, downloadFileName) {
-        if (err) {
-          res.status(500).send('Error generating file');
-          console.error('Error generating file for multiple voters');
-          console.error(err);
-          return;
-        }
-        res.header('Access-Control-Expose-Headers', "Filename");
-        res.header('Filename', downloadFileName);
-        res.download(filepath, downloadFileName, function (err) {
-           if (err) {
-              console.log("Error downloading all letters.");
-              console.log(err);
-           } else {
-              console.log("Success downloading all letters.");
-           }
-        });
-      });
+    // include the userId from the JWT to make sure the user 
+    //  has access to that voter
+    const params = { userId: req.user.sub };
+    if (req.query.voter_id) {
+      params.voterId = req.query.voter_id;
+    }
+    voterService.getVoters(params)
+    .then((voters) => {
+      if (voters.length === 0) {
+        res.status(500).send('No voters found');
+      } else {
+        voterService.downloadLetterUrl(params)
+          .then((url) => {
+            res.json({ url });
+          })
+          .catch((err) => {
+            res.status(500).send('error getting url');
+          });
+      }
+    })
   });
 
 router.route('/voter/confirm-prepped')

--- a/server/server.js
+++ b/server/server.js
@@ -98,6 +98,7 @@ function downloadFileCallback(res) {
       return;
     }
     res.header('Access-Control-Expose-Headers', "Filename");
+    res.header('Content-Type', "application/pdf");
     res.header('Filename', downloadFileName);
     res.download(filepath, downloadFileName, function (err) {
         if (err) {

--- a/src/VoterList.js
+++ b/src/VoterList.js
@@ -3,7 +3,6 @@
 import React, { Component } from 'react';
 import axios from 'axios';
 import moment from 'moment';
-import download from 'js-file-download';
 
 class VoterRecord extends Component {
   constructor(props) {
@@ -13,14 +12,14 @@ class VoterRecord extends Component {
 
   downloadLetterForVoter(voter_id) {
     axios({
-     method: 'GET',
+      method: 'GET',
       headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
-      url: `${process.env.REACT_APP_API_URL}/voters/downloadLetter`,
+      url: `${process.env.REACT_APP_API_URL}/voters/letterUrl`,
       params: { voter_id: voter_id },
-      responseType: "blob"
+      responseType: "json"
     })
     .then(res => {
-      download(res.data, res.headers.filename);
+      window.open(`${process.env.REACT_APP_API_URL}/letters/${res.data.url}`);
     })
     .catch(err => {
       console.error(err);
@@ -111,13 +110,13 @@ export class VoterList extends Component {
     axios({
      method: 'GET',
       headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
-      url: `${process.env.REACT_APP_API_URL}/voters/downloadAllLetters`,
+      url: `${process.env.REACT_APP_API_URL}/voters/letterUrl`,
       params: { user_id: localStorage.getItem('user_id')},
-      responseType: "blob"
+      responseType: "json"
     })
     .then(res => {
-      download(res.data, res.headers.filename);
       this.setState({downloadingBundle: false});
+      window.open(`${process.env.REACT_APP_API_URL}/letters/${res.data.url}`);
     })
     .catch(err => {
       console.error(err);

--- a/src/VoterList.js
+++ b/src/VoterList.js
@@ -19,7 +19,12 @@ class VoterRecord extends Component {
       responseType: "json"
     })
     .then(res => {
-      window.open(`${process.env.REACT_APP_API_URL}/letters/${res.data.url}`);
+      // this is sort of poor form with React, but can't figure out a better
+      //   way to do it right now
+      var link = document.createElement('a');
+      link.href = `${process.env.REACT_APP_API_URL}/letters/${res.data.url}`;
+      document.body.appendChild(link);
+      link.click();
     })
     .catch(err => {
       console.error(err);
@@ -116,7 +121,12 @@ export class VoterList extends Component {
     })
     .then(res => {
       this.setState({downloadingBundle: false});
-      window.open(`${process.env.REACT_APP_API_URL}/letters/${res.data.url}`);
+      // this is sort of poor form with React, but can't figure out a better
+      //   way to do it right now
+      var link = document.createElement('a');
+      link.href = `${process.env.REACT_APP_API_URL}/letters/${res.data.url}`;
+      document.body.appendChild(link);
+      link.click();
     })
     .catch(err => {
       console.error(err);


### PR DESCRIPTION
This fixes the ipad issue by constructing a short-lived url containing a jwt that displays the pdf, and then does a window.open.  On most browsers, this will flash open a new tab and then close it immediately and download the pdf after that.  Not the ideal user experience, but probably fine.  For chrome on ipad, it opens a new tab and just keeps it there where the user can print.