### PR TITLE
Add separate buttons for sign up and login.

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -81,7 +81,7 @@ export default class Auth {
     return new Date().getTime() < expiresAt;
   }
 
-  login() {
-    this.webAuth.authorize();
+  login(showLoginPage) {
+    this.webAuth.authorize({ login_hint: showLoginPage ? "login" : "signup" });
   }
 }

--- a/src/District.js
+++ b/src/District.js
@@ -10,7 +10,7 @@ import { Footer } from './Footer';
 
 class DistrictCallToAction extends Component {
   render() {
-    const buttonText = "Send letters to " + this.props.district.district_id;
+    const signUpText = "Sign up to send letters to " + this.props.district.district_id;
     return ( this.props.auth.isAuthenticated() ? (
       <div>
         <a
@@ -21,7 +21,7 @@ class DistrictCallToAction extends Component {
         </a>
       </div>
     ) : (
-      <Login auth={this.props.auth} buttonText={buttonText} />
+      <Login auth={this.props.auth} signUpText={signUpText} />
     ));
   }
 }

--- a/src/Login.js
+++ b/src/Login.js
@@ -8,9 +8,14 @@ export class Login extends Component {
     this.props.history.replace(`/${route}`)
   }
 
+  signup() {
+    GA.trackEvent('click', 'clickedSignupButton');
+    this.props.auth.login(false)
+  }
+
   login() {
     GA.trackEvent('click', 'clickedLoginButton');
-    this.props.auth.login()
+    this.props.auth.login(true)
   }
 
   logout() {
@@ -19,9 +24,9 @@ export class Login extends Component {
   }
 
   render() {
-    let buttonText = 'Log In';
-    if (this.props.buttonText) {
-      buttonText = this.props.buttonText;
+    let signUpText = 'Sign Up';
+    if (this.props.signUpText) {
+      signUpText = this.props.signUpText;
     }
     const { isAuthenticated } = this.props.auth;
     const pictureUrl = localStorage.getItem('picture_url');
@@ -31,9 +36,14 @@ export class Login extends Component {
         <React.Fragment>
           {
             !isAuthenticated() && (
-              <button onClick={this.login.bind(this)} className="btn btn-success btn-lg w-100">
-                {buttonText}
-              </button>
+              <div>
+                <button onClick={this.signup.bind(this)} style={{ marginBottom:"10px"}} className="btn btn-success btn-lg w-100">
+                  {signUpText}
+                </button>
+                <button onClick={this.login.bind(this)} className="btn btn-primary w-100">
+                  Already have an account? Login
+                </button>
+              </div>
             )
           }
           {

--- a/src/Masthead.js
+++ b/src/Masthead.js
@@ -75,7 +75,7 @@ export class Masthead extends Component {
                   <React.Fragment>
                     <div className="p-2">
                       <div className="rounded p-2 bg-white">
-                        <Login auth={this.props.auth} buttonText="Log in and send letters" />
+                        <Login auth={this.props.auth} signUpText="Sign up to send letters" />
                       </div>
                       <p className="mt-3 small text-white">
                         <a href="#privacy-notice" onClick={this.showPrivacyNotice}>


### PR DESCRIPTION
There's confusion when people are trying to sign up, and
the default auth0 screen is for login. This tries to solve
the problem by adding distinct buttons for logging in versus
signing up, and based on which is selected displaying a different
screen in the auth0 widget.

This is achieved by (ab)using the `login_hint` request parameter
in the oauth2 flow. We send `login_hint=login` if the user presses
the `login` button and `login_hint=signUp` if they press `signUp`
button. Then we configure the Auth0 Lock widget to render the desired
screen by setting the [`initialScreen` config parameter](https://auth0.com/docs/libraries/lock/v11/configuration#initialscreen-string-)
based on the passed value.

Note - because the actual login widget and configuration is hosted
by Auth0, the changes are not part of this commit. But for those interested,
the change I made was to add the following to the initialization code:
```javascript
initialScreen: config.extraParams.login_hint === 'login' ? 'login' : 'signUp'
```

Fixes #154