### PR TITLE
Batch approval of pending users

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -544,6 +544,25 @@ router.route('/s/updateUserQualifiedState')
     });
   });
 
+router.route('/s/batchApprovePending')
+  .post(checkJwt, checkAdmin, function(req, res) {
+    const auth0_ids = req.body.auth0_ids;
+    if (!auth0_ids) {
+      res.status(400).end();
+      return;
+    }
+    console.log("Batch approving pending for auth0_ids: ", auth0_ids);
+    userService.batchApprovePending(auth0_ids, function (error, newState){
+      if (error) {
+        console.error(error);
+        res.status(500).end();
+        return;
+      }
+      res.status(200).send('Batch approved pending.').end();
+      return;
+    });
+  });
+
 // Check that a user is an admin.  You have to be an admin to do so, but you can
 // check on another user.
 router.route('/s/isAdmin')

--- a/server/userService.js
+++ b/server/userService.js
@@ -114,7 +114,7 @@ function notifyUserOfNewQualifiedState(user, newState){
   // their old state to their new state.  Depending on what changed we might want to send them
   // an email so they are aware of this change.
   // Note that user['qual_state'] is their *previous* state and newState is their just set current state.
-  console.log("Notifying user of updated status.", user);
+  console.log("Notifying user of updated status.");
   if (user['qual_state'] == QualStateEnum.pre_qualified && newState == QualStateEnum.qualified) {
     //notify users when promoted to qualified
     return notifyUserOfBasicQualifiedState(user);
@@ -132,7 +132,7 @@ function notifyUserOfNewQualifiedState(user, newState){
 
 function notifyUserOfBasicQualifiedState(user) {
   if (process.env.NODE_ENV !== 'test') {
-    console.log("Notifing user of basic approval.", user.email);
+    console.log("Notifing user of basic approval.");
     emailService.sendEmail('qualified', user, 'You\'re approved to send letters on Vote Forward');
   }
   return 'sent qualified email';

--- a/server/userService.js
+++ b/server/userService.js
@@ -87,12 +87,11 @@ function updateUserQualifiedState(auth0_id, qualState, callback){
 }
 
 function batchApprovePending(auth0_ids, callback){
-  console.log("Service batch approving pending for auth0_ids: ", auth0_ids);
-  // takes a list of auth0_ids of users and approves them.
+  // Takes a list of auth0_ids of users and approves them.
+  //
   // This function should only be called by admins and verified through
   // a middleware.
 
-  // get the user for email sending and then update that state for the user
   db('users')
   .whereIn('auth0_id', auth0_ids)
   .andWhere({qual_state: QualStateEnum.pre_qualified})

--- a/server/userService.js
+++ b/server/userService.js
@@ -93,8 +93,8 @@ function batchApprovePending(auth0_ids, callback){
   // a middleware.
   db('users')
   .whereIn('auth0_id', auth0_ids)
+  .whereRaw('length(why_write_letters) > 0')
   .andWhere({qual_state: QualStateEnum.pre_qualified})
-  .andWhereNotNull({why_write_letters})
   .update({qual_state: QualStateEnum.qualified})
   .returning(['email', 'qual_state'])
   .then(function(users) {

--- a/server/userService.js
+++ b/server/userService.js
@@ -194,5 +194,6 @@ module.exports = {
   updateEmail,
   updateUserQualifiedState,
   notifyUserOfNewQualifiedState,
+  notifyUserOfBasicQualifiedState,
   _prepForTests
 }

--- a/server/userService.js
+++ b/server/userService.js
@@ -94,6 +94,7 @@ function batchApprovePending(auth0_ids, callback){
   db('users')
   .whereIn('auth0_id', auth0_ids)
   .andWhere({qual_state: QualStateEnum.pre_qualified})
+  .andWhereNotNull({why_write_letters})
   .update({qual_state: QualStateEnum.qualified})
   .returning(['email', 'qual_state'])
   .then(function(users) {

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -347,12 +347,14 @@ class UserTable extends Component {
         <div className="text-center mt-2 mb-2">
           {!this.state.batchApproving && batchApproveButton}
           {this.state.batchApproving &&
-          <form>
+          <div>
             <p className="mr-4 ml-4 small">Are you sure you want to batch approve all pending volunteers? This cannot be undone.</p>
-            <input className="btn btn-danger btn-small" type="submit" value="Batch Approve Pending"
-            onClick={this.handleBatchApprovePending.bind(this, users)}
-            />
-          </form>
+            <button className="btn btn-info btn-small mr-2" type="cancel"
+            onClick={() => {this.cancelBatchApproval()}}>Cancel</button>
+
+            <button className="btn btn-danger btn-small ml-2" type="submit"
+            onClick={this.handleBatchApprovePending.bind(this, users)}>Batch Approve Users</button>
+          </div>
           }
         </div>
         <ReactTable data={users} columns={columns} className="-striped -highlight" />

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -19,6 +19,7 @@ class UserTable extends Component {
     this.renderStatus = this.renderStatus.bind(this);
     this.renderNameAndProfile = this.renderNameAndProfile.bind(this);
     this.handleChangeStatus = this.handleChangeStatus.bind(this);
+    this.handleBatchApprovePending = this.handleBatchApprovePending.bind(this);
     this.hideUserInformation = this.hideUserInformation.bind(this);
   }
 
@@ -68,6 +69,26 @@ class UserTable extends Component {
           })
         }
       });
+    })
+    .catch(err => {
+      console.error(err);
+    });
+  }
+
+  handleBatchApprovePending(users, event) {
+    event.preventDefault();
+    const auth0_ids = users.map(user => user.auth0_id)
+    console.log("Handling batch approve pending for auth0_ids: ", auth0_ids);
+    axios({
+      method: 'POST',
+      headers: {Authorization: 'Bearer '.concat(localStorage.getItem('access_token'))},
+      url: `${process.env.REACT_APP_API_URL}/s/batchApprovePending`,
+      data: {
+        auth0_ids: auth0_ids,
+      }
+    })
+    .then(res => {
+      window.location.reload();
     })
     .catch(err => {
       console.error(err);
@@ -302,6 +323,11 @@ class UserTable extends Component {
             closeModal={this.hideUserInformation}
           />
         )}
+        <form>
+          <input type="submit" value="Batch Approve Pending"
+          onClick={this.handleBatchApprovePending.bind(this, users)}
+          />
+        </form>
         <ReactTable data={users} columns={columns} className="-striped -highlight" />
       </React.Fragment>
     )}

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -14,12 +14,17 @@ class UserTable extends Component {
   constructor(props) {
     super(props)
 
-    this.state = { users: [], activeUserProfile: null };
+    this.state = {
+      users: [],
+      activeUserProfile: null,
+      batchApproving: false
+    };
     this.getAllUsers = this.getAllUsers.bind(this);
     this.renderStatus = this.renderStatus.bind(this);
     this.renderNameAndProfile = this.renderNameAndProfile.bind(this);
     this.handleChangeStatus = this.handleChangeStatus.bind(this);
     this.handleBatchApprovePending = this.handleBatchApprovePending.bind(this);
+    this.cancelBatchApproval = this.cancelBatchApproval.bind(this);
     this.hideUserInformation = this.hideUserInformation.bind(this);
   }
 
@@ -89,10 +94,15 @@ class UserTable extends Component {
     })
     .then(res => {
       window.location.reload();
+      this.cancelBatchApproval();
     })
     .catch(err => {
       console.error(err);
     });
+  }
+
+  cancelBatchApproval() {
+    this.setState({batchApproving: false});
   }
 
   renderStatus(props) {
@@ -315,6 +325,17 @@ class UserTable extends Component {
       sortable: false
     }];
 
+
+    let batchApproveButton;
+    if(!this.state.batchApproving) {
+      batchApproveButton = (
+        <button className="btn btn-warning btn-sm"
+          onClick={() => {this.setState({batchApproving: true})}}>
+          Dangerously Batch Approve Users
+        </button>
+      )
+    }
+
     return (
       <React.Fragment>
         {this.state.activeUserProfile && (
@@ -323,14 +344,21 @@ class UserTable extends Component {
             closeModal={this.hideUserInformation}
           />
         )}
-        <form>
-          <input type="submit" value="Batch Approve Pending"
-          onClick={this.handleBatchApprovePending.bind(this, users)}
-          />
-        </form>
+        <div className="text-center mt-2 mb-2">
+          {!this.state.batchApproving && batchApproveButton}
+          {this.state.batchApproving &&
+          <form>
+            <p className="mr-4 ml-4 small">Are you sure you want to batch approve all pending volunteers? This cannot be undone.</p>
+            <input className="btn btn-danger btn-small" type="submit" value="Batch Approve Pending"
+            onClick={this.handleBatchApprovePending.bind(this, users)}
+            />
+          </form>
+          }
+        </div>
         <ReactTable data={users} columns={columns} className="-striped -highlight" />
       </React.Fragment>
-    )}
+    );
+  }
 }
 
 class Admin extends Component {

--- a/src/routes.js
+++ b/src/routes.js
@@ -58,6 +58,7 @@ export const makeMainRoutes = () => {
           <Route exact path="/vote" render={(props) => <Pledge auth={auth} {...props} />} />
           <Route exact path="/verify" render={(props) => <Verify auth={auth} {...props} />} />
           <AdminRoute exact path="/admin" component={Admin} auth={auth} />
+          <AdminRoute exact path="/batch_approve_pending" component={Admin} auth={auth} />
           <AdminRoute exact path="/admin/districts" component={Districts} auth={auth} />
           <AdminRoute path="/admin/user/:id" component={AdminUser} auth={auth} />
           <Route exact path="/privacy-policy" render={(props) => <Privacy auth={auth} {...props} />} />

--- a/test/userService-test.js
+++ b/test/userService-test.js
@@ -155,28 +155,22 @@ describe('userService', function() {
     });
   });
 
-  describe('notifyUserOfNewQualifiedState', function() {
+  describe('batchApprovePending', function() {
+    it('should succeed on setting pre_qualified state to qualified', function(done) {
+      userService.batchApprovePending([this.users.regular.auth0_id], function(error, newState) {
+        if (error) {
+          return done(error);
+        }
+        expect(newState).to.be.eql('qualified', 'incorrect or missing newState for test. Expected: qualified. Got: ' + newState);
+        done();
+      });
+    });
+  });
+
+  describe('notifyUserOfBasicQualifiedState', function() {
     it('should send a qualified email on promotion of pre_qualified to qualified', function(done) {
-      var result = userService.notifyUserOfNewQualifiedState(this.users.prequal, 'qualified');
+      var result = userService.notifyUserOfBasicQualifiedState(this.users.prequal);
       expect(result).to.be.eql('sent qualified email');
-      done();
-    });
-
-    it('should send a super_qualified email on promotion of pre_qualified to super_qualified', function(done) {
-      var result = userService.notifyUserOfNewQualifiedState(this.users.prequal, 'super_qualified');
-      expect(result).to.be.eql('sent super_qualified email');
-      done();
-    });
-
-    it('should send a super_qualified email on promotion of pre_qualified to super_qualified', function(done) {
-      var result = userService.notifyUserOfNewQualifiedState(this.users.qual, 'super_qualified');
-      expect(result).to.be.eql('sent super_qualified email');
-      done();
-    });
-
-    it('should not send an email on banned', function(done) {
-      var result = userService.notifyUserOfNewQualifiedState(this.users.qual, 'banned');
-      expect(result).to.be.eql('not sending an email');
       done();
     });
 


### PR DESCRIPTION
See #182

Implementation:
* A new button in the admin UI
* A route for the new API endpoint
* A service library for making the update.

The service will only approve the list of curently loaded users (i.e.
the bound React data), and only those which are in pending state.

Importantly, the steps an admin must follow:

1. Load the admin page.
2. Manually remove flagged pending accounts (using @sjforman's
incantations).
3. Click on "Batch Approve".

If you refresh the page before step 3, it's possible someone could have
signed up in the interim.

Next steps should be:
1. Add some guard around this button. E.g. a "Confirm I cam Scott Forman
and that I really want to do this" checkbox.
2. Allow the admin to read the submission text and ban accounts (e.g.
what Scott is doing in the DB today).