### PR TITLE
Stop assigning volunteers to empty districts

### DIFF
--- a/migrations/20181012211527_create_view_districts_with_unclaimed_voters.js
+++ b/migrations/20181012211527_create_view_districts_with_unclaimed_voters.js
@@ -2,15 +2,16 @@
 
 exports.up = function(knex, Promise) {
   const createView =
-  `create or replace view districts_with_voters as
+  `create or replace view districts_with_unclaimed_voters as
   select d.*
   from districts d
   where exists (
       select * from voters v
-      where v.district_id = d.district_id);`
+      where v.district_id = d.district_id
+      and v.adopter_user_id is null);`
   return knex.raw(createView);
 };
 
 exports.down = function(knex, Promise) {
-  return knex.raw(`drop view districts_with_voters`);
+  return knex.raw(`drop view districts_with_unclaimed_voters`);
 };

--- a/migrations/20181012211527_create_view_districts_with_voters.js
+++ b/migrations/20181012211527_create_view_districts_with_voters.js
@@ -1,0 +1,16 @@
+'use strict';
+
+exports.up = function(knex, Promise) {
+  const createView =
+  `create or replace view districts_with_voters as
+  select d.*
+  from districts d
+  where exists (
+      select * from voters v
+      where v.district_id = d.district_id);`
+  return knex.raw(createView);
+};
+
+exports.down = function(knex, Promise) {
+  return knex.raw(`drop view districts_with_voters`);
+};

--- a/server/server.js
+++ b/server/server.js
@@ -378,7 +378,7 @@ router.route('/lookup-zip')
         } else {
           const ziplat = result[0].lat;
           const ziplong = result[0].long;
-          const table = 'districts_with_voters'
+          const table = 'districts_with_unclaimed_voters'
           const distanceString = `point(${ziplat}, ${ziplong}) <-> point(${table}.coordinates) as distance`;
           let nearestDistrict;
           db(table)
@@ -387,7 +387,6 @@ router.route('/lookup-zip')
             .limit(1)
           .then(function(result) {
             nearestDistrict = result[0].district_id;
-            console.log(`nearestDistrict:`, nearestDistrict)
             res.json(nearestDistrict);
           })
           .catch(err => {console.error(err);});

--- a/server/server.js
+++ b/server/server.js
@@ -112,7 +112,7 @@ function downloadFileCallback(res) {
 }
 // Keep /downloadLetter route so that after deployment
 //   people who don't refresh their browser won't get
-//   errors. 
+//   errors.
 router.route('/voters/downloadLetter')
   .get(checkJwt, function(req, res) {
     const params = { userId: req.user.sub, voterId: req.query.voter_id };
@@ -128,7 +128,7 @@ router.route('/voters/downloadLetter')
 
 // Keep /downloadAllLetters route so that after deployment
 //   people who don't refresh their browser won't get
-//   errors. 
+//   errors.
 router.route('/voters/downloadAllLetters')
   .get(checkJwt, function(req, res) {
     voterService.downloadAllLetters(req.user.sub, downloadFileCallback(res));
@@ -144,14 +144,14 @@ router.route('/letters/:letterJwt.pdf')
 
 
 /**
- * This route creates a secure url that can be used to download the pdf.  It 
- * creates a one-minute-long JWT that gets included in the url 
+ * This route creates a secure url that can be used to download the pdf.  It
+ * creates a one-minute-long JWT that gets included in the url
  * that contains either userId and voterId to download a single voter's pdf,
  * or just the userId to download all voters for that user.
  */
 router.route('/voters/letterUrl')
   .get(checkJwt, function(req, res) {
-    // include the userId from the JWT to make sure the user 
+    // include the userId from the JWT to make sure the user
     //  has access to that voter
     const params = { userId: req.user.sub };
     if (req.query.voter_id) {
@@ -378,14 +378,16 @@ router.route('/lookup-zip')
         } else {
           const ziplat = result[0].lat;
           const ziplong = result[0].long;
-          const distanceString = `point(${ziplat}, ${ziplong}) <-> point(districts.coordinates) as distance`;
+          const table = 'districts_with_voters'
+          const distanceString = `point(${ziplat}, ${ziplong}) <-> point(${table}.coordinates) as distance`;
           let nearestDistrict;
-          db('districts')
+          db(table)
             .select('district_id', db.raw(distanceString))
             .orderBy('distance', 'asc')
             .limit(1)
           .then(function(result) {
             nearestDistrict = result[0].district_id;
+            console.log(`nearestDistrict:`, nearestDistrict)
             res.json(nearestDistrict);
           })
           .catch(err => {console.error(err);});


### PR DESCRIPTION
Updated to check for unclaimed voters.  Test as follows:

```
update voters 
set adopter_user_id = '[VALID USER ID]' 
where district_id = 'OH12';
```
Create a new user with zip code 43214

Before running the migration, that user will be assigned to OH12; after the migration, to PA10.
