### PR TITLE
convert voter "Prepared?" checkmark buttons to arrows

### DIFF
--- a/src/VoterList.js
+++ b/src/VoterList.js
@@ -47,7 +47,7 @@ class VoterRecord extends Component {
         <div>
           <span className="small u-quiet mr-2">Prepared?</span>
           <button className="btn btn-sm btn-success" onClick={() => {this.props.confirmPrepped(voter)}}>
-            <i className="fa fa-check" aria-hidden="true"></i>
+            <i className="fa fa-arrow-right" aria-hidden="true"></i>
           </button>
         </div>
       );

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -201,6 +201,10 @@ input + .btn {
 .btn-fat-border {
   border: 5px solid #fff; }
 
+.btn-success .fa-arrow-right {
+  position: relative;
+  top: -1px; }
+
 label {
   font-weight: bold; }
 

--- a/src/scss/_global.scss
+++ b/src/scss/_global.scss
@@ -225,6 +225,11 @@ input + .btn {
   border: 5px solid $white;
 }
 
+.btn-success .fa-arrow-right {
+  position: relative;
+  top: -1px;
+}
+ 
 // Form Inputs
 
 label {


### PR DESCRIPTION
Changes "checkmark" style icons to arrows; intended to reduce confusion for users who may think the checkmark means it's already been prepared.

![image](https://user-images.githubusercontent.com/1408929/46927420-4cfe1780-d003-11e8-82e1-78b338cae325.png)
