### PR TITLE
Modify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ To compile, run this script in a second tab in your terminal:
 
 	npm run scss-compile
 
-#### How to make a new database migration (if you need it...)
+#### How to make a new database migration (if you need it...not part of initial setup)
 
 	`knex migrate:make <migration_file_name>`.  Naming examples in the /migrations folder.  Note you dont need the datestring or the .js, so you can do a name like `add_index_on_qual_state_for_users`.
 

--- a/README.md
+++ b/README.md
@@ -126,13 +126,8 @@ Load the district data:
 
 These voter records consist of randomized names and addresses.
 
-#### Make a new database migration
 
-`knex migrate:make <migration_file_name>`.  Naming examples in the /migrations folder.  Note you dont need the datestring or the .js, so you can do a name like `add_index_on_qual_state_for_users`.
-
-`knex migrate:latest` to apply it and `knex migrate:rollback` to go back.
-
-#### Start devloping
+#### Start developing
 
 	npm run start-dev
 
@@ -152,3 +147,9 @@ Make sure to update SCSS files and not the compiled CSS files. Note that buildin
 To compile, run this script in a second tab in your terminal:
 
 	npm run scss-compile
+
+#### How to make a new database migration (if you need it...)
+
+	`knex migrate:make <migration_file_name>`.  Naming examples in the /migrations folder.  Note you dont need the datestring or the .js, so you can do a name like `add_index_on_qual_state_for_users`.
+
+	`knex migrate:latest` to apply it and `knex migrate:rollback` to go back.


### PR DESCRIPTION
README changed so instructions to create a new knex db migration are at the bottom of the README and labelled to make it clear that they are not part of the initial setup