### PR TITLE
Add support and contact pages

### DIFF
--- a/src/Contact.js
+++ b/src/Contact.js
@@ -1,0 +1,42 @@
+// src/Privacy.js
+
+import React, { Component } from 'react';
+import { Header } from './Header';
+import { Footer } from './Footer';
+
+class Contact extends Component {
+  render() {
+    return (
+      <div>
+        <Header auth={this.props.auth}/>
+
+    <header className="header bg-light">
+      <div className="container">
+        <div className="row">
+          <div className="h-100 text-center m-auto">
+            <h1 className="mb-4 mt-4 pb-4 mb-lg-0">Contact Us</h1>
+          </div>
+        </div>
+      </div>
+    </header>
+
+        <div className="container">
+        <div className="row col-lg-8 m-auto">
+          <div className="text-body h-100 mt-4 mb-4 text-lg-left">
+            <p>Vote Forward is an independent organization that encourages voter turnout and helps volunteers elect candidates who reflect our values through a variety of activities aimed at influencing the outcome of the next election.</p>
+            <h4>Mailing Address</h4>
+            <p>P.O. Box 28522<br />
+            Oakland, CA 94604</p>
+            <p><strong>Press inquiries:</strong> <a href="mailto:press@votefwd.org">press@votefwd.org</a></p>
+            <p><strong>Questions about our process?</strong> Read our <a href="/faq">Frequently Asked Questions.</a></p>
+            <p><strong>Need help?</strong> Visit our <a href="/support">support page.</a></p>
+          </div>
+        </div>
+      </div>
+    <Footer />
+  </div>
+    );
+  }
+}
+
+export default Contact

--- a/src/Contact.js
+++ b/src/Contact.js
@@ -1,4 +1,4 @@
-// src/Privacy.js
+// src/Contact.js
 
 import React, { Component } from 'react';
 import { Header } from './Header';
@@ -23,7 +23,7 @@ class Contact extends Component {
         <div className="container">
         <div className="row col-lg-8 m-auto">
           <div className="text-body h-100 mt-4 mb-4 text-lg-left">
-            <p>Vote Forward is an independent organization that encourages voter turnout and helps volunteers elect candidates who reflect our values through a variety of activities aimed at influencing the outcome of the next election.</p>
+            <p>Vote Forward is an independent 527 nonprofit organization that connects citizens to one another to increase voter turnout, especially among Democrats.</p>
             <h4>Mailing Address</h4>
             <p>P.O. Box 28522<br />
             Oakland, CA 94604</p>

--- a/src/Faq.js
+++ b/src/Faq.js
@@ -12,13 +12,16 @@ class QsAndAs extends Component {
 
           <div className="mb-5">
             <h1>Frequently Asked Questions </h1>
-            <p>If you have a question not addressed here, please send an email to <a href="mailto:help@votefwd.org">help@votefwd.org</a>.</p>
+            <p>Already signed up but need help? Try our <a href="/support">support page</a>.</p>
           </div>
 
           <div className="mb-5">
             <h2>What does the letter-writing process entail?</h2>
             <p>
-              When you first sign up, you’ll be asked a few basic questions to make sure you’re a human being with good intentions. We review and approve new volunteers at least twice a day, so within 12 hours or so, you should receive a welcome email with detailed instructions. After clicking a button to “adopt” some voters, you’ll download and print a PDF, then hand-write a single sentence on each letter, address, stamp, and set it aside to send on October 30. <a href="https://www.youtube.com/watch?v=UCPb-SFWYB4" target="_blank" rel="noopener noreferrer">Link to a demo video on YouTube.</a>
+              When you first sign up, you’ll be asked a few basic questions to make sure you’re a human being with good intentions. We review and approve new volunteers at least twice a day, so within 12 hours or so, you should receive a welcome email with detailed instructions. After clicking a button to “adopt” some voters, you’ll download and print a PDF, then hand-write a single sentence on each letter, address, stamp, and set it aside to send on October 30.</p>
+              
+            <p>
+              Want to see the process in action? Here’s a <a href="/vote-forward-instructions.pdf" target="_blank" rel="noopener noreferrer">printed overview</a> and <a href="https://www.youtube.com/watch?v=UCPb-SFWYB4" target="_blank" rel="noopener noreferrer">a video</a>.
             </p>
           </div>
 

--- a/src/Footer.js
+++ b/src/Footer.js
@@ -12,7 +12,7 @@ export class Footer extends Component {
 					<div className="col-lg-6 h-100 text-center text-lg-left my-auto">
 					<p className="text-white small mb-4 mb-lg-0">Copyright &copy; Vote Forward 2018. All Rights Reserved.</p>
 			    <p className="text-white link small">
-            <a href="/faq">FAQ</a> &#9702; <a href="/privacy-policy">Privacy Policy</a> &#9702; <a href="/terms-of-use">Terms of Use</a> &#9702; <a target="_blank" rel="noopener noreferrer" href="https://bit.ly/votefwd-contact">Contact</a> &#9702; <a target="_blank" rel="noopener noreferrer" href="https://bit.ly/votefwd-donate">Donate</a>
+            <a href="/faq">FAQ</a> &#9702; <a href="/privacy-policy">Privacy Policy</a> &#9702; <a href="/terms-of-use">Terms of Use</a> &#9702; <a href="/contact">Contact</a> &#9702; <a href="/support">Support</a> &#9702; <a target="_blank" rel="noopener noreferrer" href="https://bit.ly/votefwd-donate">Donate</a>
           </p>
 			    <p className="text-white link small">
             <a href="/vote-forward-party-kit.pdf" target="_blank" rel="noopener noreferrer">Party Kit</a> &#9702;

--- a/src/Support.js
+++ b/src/Support.js
@@ -1,0 +1,121 @@
+// src/Privacy.js
+
+import React, { Component } from 'react';
+import { Header } from './Header';
+import { Footer } from './Footer';
+
+class Support extends Component {
+  render() {
+    return (
+      <div>
+        <Header auth={this.props.auth}/>
+
+          <div className="container">
+          
+            <div className="p-5">
+
+              <div className="mb-5">
+                <h1>Help and Support</h1>
+                <p>This page is for technical issues. Have questions about the process? Try our <a href="/support">Frequently Asked Questions</a>.</p>
+
+              </div>
+              
+              <div className="mb-5">
+                <h2>I can’t sign in!</h2>
+                <p>
+                  We’re so sorry! You may be having trouble for these reasons:
+                </p>
+                <ul>
+                  <li><strong>Haven’t signed up yet?</strong> <a href="/">Sign up for an account</a> first. We’ll ask for your name, email address, and zip code, and the approval process takes 12-36 hours. Once you’re in, you’ll be able to adopt voters and print letters.</li>
+                  <li><strong>Just signed up?</strong> The approval process takes 12-36 hours, and you’ll get an email when your account is approved. (Check your spam folder if it’s been longer, or just try <a href="/dashboard">logging in anyway</a>.)</li>
+                  <li><strong>My password doesn’t work!</strong> This might happen if you signed up using your Facebook or Google account; if you did, you’ll need to use the same method to log back in. Try <a href="/dashboard">logging back in</a>, but using your Google or Facebook account instead, if that’s what you used to sign up.</li>
+                  <li><strong>I can’t reset my password!</strong> If you signed up using a Facebook or Google account, there’s no password to reset (but for security reasons, the system won’t say so). Try <a href="/dashboard">logging back in</a>, but using your Google or Facebook account instead, if that’s what you used to sign up.</li>
+                  <li><strong>It just won’t work!</strong> As a last resort, try restarting your browser (or better yet, your whole computer) and <a href="/">trying again</a>. If you’re still stuck, get in touch with us at the bottom of this page.</li>
+                </ul>
+
+              </div>
+              
+              <div className="mb-5">
+                <h2>I can’t print my letters!</h2>
+                <p>Try these steps:</p>
+                <ol>
+                  <li>Log in to your <a href="/dashboard">Vote Forward dashboard</a> and, if you haven’t already, adopt some voters.</li>
+                  <li>Look for the “Download All” button, which will download a PDF file of letters to your computer.</li>
+                  <li>Find that PDF file. Each computer system is different, but it’s often in a folder named “Downloads”, or it may appear automatically. (The filename will be something like <em>2018-10-08-votefwd-letters-batch-of-25.pdf</em>, though with today’s date.)</li>
+                  <li>Print that file! Names, addresses, special return addresses, and cover sheets are included. </li>
+                </ol>
+                
+              </div>
+              
+              <div className="mb-5">
+                <h2>My list of voters disappeared!</h2>
+                <p>
+                  This might happen if you signed up using a Facebook account, but logged back in using a Google account or a username and password (or vice versa). This can create duplicate accounts, which is a bug we’re working to fix. Try <a href="/dashboard">logging out and back in</a>, but using whatever you used to sign up (Facebook, Google, or a username and password).      
+                </p>
+
+              </div>
+
+              <div className="mb-5">
+                <h2>I have too many voters! Can you remove some?</h2>
+                <p>
+                Once voters are adopted, they can only be removed manually by us. To request removal:
+                </p>
+                <ol> 
+                <li>Log in to your <a href="/dashboard">dashboard</a> and mark <strong>each of the voters you have completed or will complete</strong> as “prepared.” They will move to the “Letters Prepared” list.</li>
+                <li><a href="mailto:help@votefwd.org?subject=Please+remove+extra+voters">Let us know</a> you’ve marked your voters, and we’ll manually remove the voters remaining in your “Letters to Prepare” list. (This may take 24-48 hours and we’ll email you when it’s done.)</li>
+                </ol>
+              </div>
+              
+              <div className="mb-5">
+                <h2>My district is out of names!</h2>
+                <p>
+                It’s incredible&mdash;demand has been so great that we’re starting to run out of addresses! We’re adding more voters and districts as fast we can (we have to pay for names, and loading takes time). In the meantime, click “Switch District” in your <a href="/dashboard">Vote Forward dashboard</a> to find another district with outstanding voters to adopt.
+                </p>
+              </div>
+              
+              <div className="mb-5">
+                <h2>I don’t have a printer!</h2>
+                <p>
+                You might consider using a local print shop or office supply store. They’ll often accept the PDF of letters on a thumb drive or via email. If you prefer to hand-write the letters or it’s your only option, feel free! Just be sure to include the individual voter code and web address we provide at the bottom of our pre-printed letters; that’s for the recipient to use on our website to find out more info about the election.
+                </p>
+              </div>
+
+              <div className="mb-5">
+                <h2>One of the addresses is bad!</h2>
+                <p>
+                We have occasionally run into a few bad addresses in the database. Our best advice for now is to move on and complete other letters. Feel free to mark that voter as “prepared” so it doesn’t get reprinted if you decide to adopt more voters.
+                </p>                
+              </div>      
+
+              <div className="mb-5">
+                <h2>Should I send the letters early?</h2>
+                <p>
+                We‘re very confident October 30 is the right choice. There’s strong evidence that the effects of these messages fade quickly. The advantages of sending earlier&mdash;including for early voting and vote-by-mail&mdash;are almost certainly outweighed by the disadvantages.</p>
+                <p>However, <em>if you’re mailing from outside the continental United States,</em> please do send them a bit earlier, as appropriate for your location.
+                </p>                
+              </div>     
+                                              
+              <div className="mb-5">
+                <h2>Why is the voter’s name and address, and a special code, in the letter?</h2>
+                <p>
+                The code is unique to each voter, and should stay. It lets them use the website to get detailed information about their own ballot, and confirm their pledge to vote.
+                </p>                
+              </div>              
+
+              <div className="mb-5">
+                <h2>Still stuck?</h2>
+                <p>
+                  Send us an email at <a href="mailto:help@votefwd.org">help@votefwd.org</a>. We’re a small group of volunteers, and demand has been extraordinary, so we may be a little slow to respond. We’ll reply as soon as we can, and thank you! 
+                </p>
+              </div>
+              
+            </div>        
+          
+          </div>
+        <Footer />
+      </div>
+    );
+  }
+}
+
+export default Support

--- a/src/Support.js
+++ b/src/Support.js
@@ -98,7 +98,7 @@ class Support extends Component {
               <div className="mb-5">
                 <h2>Why is the voter’s name and address, and a special code, in the letter?</h2>
                 <p>
-                The code is unique to each voter, and should stay. It lets them use the website to get detailed information about their own ballot, and confirm their pledge to vote.
+                The code is unique to each voter, and should stay. Each recipient gets their own “unique code” that they can use to get more information about the election in their district, and to pledge that they will vote. They do this by visiting <a href="https://votefwd.org/vote">https://votefwd.org/vote</a> and entering their unique code. You as the letter writer should not use the unique code for anything. (By the way, the “election info” promised by the letter is not yet available, but will be by the time you mail out the letters.)
                 </p>                
               </div>              
 

--- a/src/Support.js
+++ b/src/Support.js
@@ -1,4 +1,4 @@
-// src/Privacy.js
+// src/Support.js
 
 import React, { Component } from 'react';
 import { Header } from './Header';
@@ -98,7 +98,7 @@ class Support extends Component {
               <div className="mb-5">
                 <h2>Why is the voter’s name and address, and a special code, in the letter?</h2>
                 <p>
-                The code is unique to each voter, and should stay. Each recipient gets their own “unique code” that they can use to get more information about the election in their district, and to pledge that they will vote. They do this by visiting <a href="https://votefwd.org/vote">https://votefwd.org/vote</a> and entering their unique code. You as the letter writer should not use the unique code for anything. (By the way, the “election info” promised by the letter is not yet available, but will be by the time you mail out the letters.)
+                The code is unique to each voter, and should stay. Each recipient gets their own “unique code” that they can use to get more information about the election in their district, and to pledge that they will vote. They do this by visiting <a href="https://votefwd.org/vote">https://votefwd.org/vote</a> and entering their unique code. You as the letter writer should not use the unique code for anything.
                 </p>                
               </div>              
 

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -58,8 +58,11 @@ h6 {
   font-family: 'Raleway', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 700; }
 
-p {
+p, ul, ol, blockquote {
   font-size: 1.2rem; }
+
+li {
+  margin-bottom: 0.5rem; }
 
 .alert {
   background: white;

--- a/src/routes.js
+++ b/src/routes.js
@@ -15,6 +15,8 @@ import Districts from './Districts';
 import Privacy from './Privacy';
 import Terms from './Terms';
 import Faq from './Faq';
+import Contact from './Contact';
+import Support from './Support';
 import history from './history';
 import GA from './utils/GoogleAnalytics';
 
@@ -63,6 +65,8 @@ export const makeMainRoutes = () => {
           <Route exact path="/privacy-policy" render={(props) => <Privacy auth={auth} {...props} />} />
           <Route exact path="/terms-of-use" render={(props) => <Terms auth={auth} {...props} />} />
           <Route exact path="/faq" render={(props) => <Faq auth={auth} {...props} />} />
+          <Route exact path="/contact" render={(props) => <Contact auth={auth} {...props} />} />
+          <Route exact path="/support" render={(props) => <Support auth={auth} {...props} />} />
         </React.Fragment>
       </Router>
   );

--- a/src/scss/_global.scss
+++ b/src/scss/_global.scss
@@ -23,8 +23,12 @@ h6 {
   font-weight: 700;
 }
 
-p {
+p, ul, ol, blockquote {
   font-size: 1.2rem;
+}
+
+li {
+  margin-bottom: 0.5rem;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The help desk is pretty swamped — 775 open tickets right now. I’m getting two folks on board, but they’ll be slow to ramp up.

So, I’d like to slow the flow by changing the “contact” link in the footer to be two links instead: “Contact” and “Support”. Contact goes to a page within the site that has a mailing address (do you have one?) and a special email for press inquiries, and a link to the support page.

The support page is an extended FAQ just for support items; the most popular ones, organized as succinctly as possible. At the very very bottom is the help@ email address for anything that’s not covered.