### PR TITLE
Fix bug preventing user view in admin screen

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -176,7 +176,7 @@ class UserTable extends Component {
       id: 'l',
       Header: 'auth0_id',
       accessor: l => {
-        return (<a href={`admin/user/${l.auth0_id}`}>{l.auth0_id}</a>);
+        return (<a href={`/admin/user/${l.auth0_id}`}>{l.auth0_id}</a>);
       },
     }, {
       Header: 'Email',


### PR DESCRIPTION
To replicate:

1. Log in and go to https://votefwd.org/admin/
2. Click on any user's auth0_id (for instance, https://votefwd.org/admin/admin/user/auth0%7C5bbe45cc90253a02377c09a7)
3. The resulting page is blank

I think there's an extra /admin being added to the URL. 