### PR TITLE
Dashboard text improvements

### DIFF
--- a/src/AdoptVoter.js
+++ b/src/AdoptVoter.js
@@ -96,7 +96,7 @@ export class AdoptVoter extends Component {
               </div>
               { maxedOut && (
                 <div className="mt-4 alert alert-info pr-4 pl-4">
-                  <p>You’ve adopted the maximum number of voters ({process.env.REACT_APP_QUAL_NUM}). Fantastic! To become a super-volunteer so you can adopt more, please <a href="mailto:super@votefwd.org?subject=Please approve me as a super-volunteer!&body=Hello! Please approve me to adopt more than 100 voters on Vote Forward. (Letter writer: replace this text with a short message to the admins and if you can, attach a photo of some of your completed letters)." target="_blank" rel="noopener noreferrer">email super@votefwd.org</a> to request approval.</p>
+                  <p>You’ve adopted the maximum number of voters ({process.env.REACT_APP_QUAL_NUM}). Fantastic! To become a super-volunteer so you can adopt more, please <a href="mailto:super@votefwd.org?subject=Please%20approve%20me%20as%20a%20super-volunteer!&amp;body=Hello!%20Please%20approve%20me%20to%20adopt%20more%20than%20100%20voters%20on%20Vote%20Forward.%20(Letter%20writer%3A%20replace%20this%20text%20with%20a%20short%20message%20to%20the%20admins%20and%20if%20you%20can%2C%20attach%20a%20photo%20of%20some%20of%20your%20completed%20letters)." target="_blank" rel="noopener noreferrer">email super@votefwd.org</a> to request approval.</p>
                 </div>
               )}
               { allClaimed && (

--- a/src/AdoptVoter.js
+++ b/src/AdoptVoter.js
@@ -51,7 +51,7 @@ export class AdoptVoter extends Component {
     if (parseInt(this.props.currentDistrict.voters_available, 10) === 0) {
       allClaimed = true;
     }
-
+    
     return (
       <div className="container-fluid p-0">
         <div className="row no-gutters position-relative">
@@ -108,7 +108,7 @@ export class AdoptVoter extends Component {
               )}
               { !maxedOut && this.props.voterCount > 0 && (
                 <div className="mt-4 alert alert-info pr-4 pl-4">
-                  <p>You’ve adopted <span className="text-success">{this.props.voterCount}</span> voters. Fantastic!</p>
+                  <p className="mb-0">You’ve adopted <span className="text-success">{this.props.voterCount}</span> voters. Fantastic!</p>
                 </div>
               )}
             </div>

--- a/src/AdoptVoter.js
+++ b/src/AdoptVoter.js
@@ -73,8 +73,8 @@ export class AdoptVoter extends Component {
                   <button
                     disabled={this.state.adopting || maxedOut || allClaimed ? true : false}
                     onClick={() => this.adoptVoter(5, this.state.district.district_id)}
-                    className="btn btn-primary btn-lg w-100 mt-1">
-                      Adopt <span className="reset-num">5</span> Voters
+                    className={'btn btn-lg w-100 mt-1 ' + ( this.props.voterCount === 0 ? 'btn-primary' : 'btn-outline-primary' ) }>
+                      Adopt <span className="reset-num">5</span> {(this.props.voterCount > 1) ? "More" : "" } Voters
                   </button>
                   <div className="small mt-1">
                     <i className="fa fa-clock-o"></i>
@@ -85,8 +85,8 @@ export class AdoptVoter extends Component {
                   <button
                     disabled={this.state.adopting || maxedOut || allClaimed ? true : false}
                     onClick={() => this.adoptVoter(25, this.state.district.district_id)}
-                    className="btn btn-primary btn-lg w-100 mt-1">
-                      Adopt <span className="reset-num">25</span> Voters
+                    className={'btn btn-lg w-100 mt-1 ' + ( this.props.voterCount === 0 ? 'btn-primary' : 'btn-outline-primary' ) }>
+                      Adopt <span className="reset-num">25</span> {(this.props.voterCount > 1) ? "More" : "" } Voters
                   </button>
                   <div className="small mt-1">
                     <i className="fa fa-clock-o"></i>

--- a/src/VoterList.js
+++ b/src/VoterList.js
@@ -39,7 +39,7 @@ class VoterRecord extends Component {
 
     if (!voter.confirmed_prepped_at) {
       voterDownloadButton = (
-        <button className="btn btn-sm btn-link" onClick={() => {this.downloadLetterForVoter(voter.id)}}>
+        <button className="btn btn-sm btn-link pl-0" onClick={() => {this.downloadLetterForVoter(voter.id)}}>
           <i className="icon-arrow-down-circle icons"></i> Download letter
         </button>
       );
@@ -47,7 +47,7 @@ class VoterRecord extends Component {
         <div>
           <span className="small u-quiet mr-2">Prepared?</span>
           <button className="btn btn-sm btn-success" onClick={() => {this.props.confirmPrepped(voter)}}>
-            <i className="fa fa-arrow-right" aria-hidden="true"></i>
+            <i className="fa fa-chevron-right" aria-hidden="true"></i>
           </button>
         </div>
       );
@@ -162,9 +162,11 @@ export class VoterList extends Component {
     let allPreppedButton;
     if (!this.state.markingAllPrepped) {
       allPreppedButton = (
-        <button disabled={this.state.downloadingBundle ? true : false} className="btn btn-light btn-sm ml-2" onClick={() => this.setState({markingAllPrepped: true})}>
-          <i className="fa fa-check"></i> All prepared
-        </button>
+        <div className="text-right">
+          <button disabled={this.state.downloadingBundle ? true : false} className="btn btn-light btn-sm mt-1" onClick={() => this.setState({markingAllPrepped: true})}>
+            Finished? Mark all letters as prepared <small><i className="fa fa-chevron-right"></i></small>
+          </button>
+        </div>
       )
     }
     else {
@@ -192,7 +194,7 @@ export class VoterList extends Component {
       if (readyToSend) {
         allSentButton = (
           <button className="btn btn-light btn-sm ml-2" onClick={() => this.setState({markingAllSent: true})}>
-            <i className="fa fa-check"></i> All sent
+            Mark all letters as sent <small><i className="fa fa-chevron-right"></i></small>
           </button>
         )
       }
@@ -222,16 +224,20 @@ export class VoterList extends Component {
         <div className="row">
           <div className="col">
             <div>
-              <div className="d-flex justify-content-between align-items-top mb-3">
+              <div className="mb-3">
                 <div>
-                  <strong>Letters to Prepare</strong> ({toPrep.length})
-                  {toPrep.length > 1 && <button disabled={this.state.downloadingBundle ? true : false} className="btn btn-light btn-sm mt-1" onClick={this.downloadBundle}>
-                    <i className="icon-arrow-down-circle icons"></i> Download all
-                  </button>}
+                  <strong>Letters to Print and Prepare</strong> ({toPrep.length})
+                  
+                  <div className="w-100">
+
+                    {toPrep.length > 1 && <button disabled={this.state.downloadingBundle ? true : false} className="btn btn-primary w-100 mt-1" onClick={this.downloadBundle}>
+                      <i className="icon-arrow-down-circle icons"></i> Download and print these letters
+                    </button>}
+                    {toPrep.length > 1 &&
+                      allPreppedButton
+                    }
+                  </div>
                 </div>
-                {toPrep.length > 1 &&
-                  allPreppedButton
-                }
               </div>
               {alertContent}
             </div>
@@ -252,13 +258,13 @@ export class VoterList extends Component {
 
           <div className="col mx-2">
             <div className="d-flex justify-content-between align-items-center mb-3">
-              <span><strong>Letters Prepared</strong> ({toSend.length})</span>
+              <span><strong>Letters You Have Prepared</strong> ({toSend.length})</span>
               {toSend.length > 1 && allSentButton}
             </div>
             <ul className="list-group">
               {toSend.length < 1 &&
                 <li className="list-group-item disabled text-center py-5 bg-light">
-                  There are no letters to send.
+                  There are no letters to mail.
                 </li>
               }
               {toSend.map(voter =>
@@ -274,12 +280,12 @@ export class VoterList extends Component {
 
           <div className="col">
             <div className="d-flex justify-content-between align-items-center mb-3">
-              <span><strong>Letters Sent</strong> ({alreadySent.length})</span>
+              <span><strong>Letters You Have Sent</strong> ({alreadySent.length})</span>
             </div>
             <ul className="list-group">
               {alreadySent.length < 1 &&
                 <li className="list-group-item disabled text-center py-5 bg-light">
-                  You haven’t sent any letters yet.
+                  You haven’t sent any letters yet.<br />(Wait until October 30!)
                 </li>
               }
               {alreadySent.map(voter =>

--- a/src/VoterList.js
+++ b/src/VoterList.js
@@ -46,7 +46,7 @@ class VoterRecord extends Component {
       voterActions = (
         <div>
           <span className="small u-quiet mr-2">Prepared?</span>
-          <button className="btn btn-sm btn-success" onClick={() => {this.props.confirmPrepped(voter)}}>
+          <button className="btn btn-sm btn-sm-icon btn-success" onClick={() => {this.props.confirmPrepped(voter)}}>
             <i className="fa fa-chevron-right" aria-hidden="true"></i>
           </button>
         </div>
@@ -55,10 +55,10 @@ class VoterRecord extends Component {
     else if (voter.confirmed_prepped_at && !voter.confirmed_sent_at) {
       voterActions = (
         <div className="btn-group">
-          <button className="btn btn-success btn-sm" onClick={() => {this.props.undoConfirmPrepped(voter)}}>
+          <button className="btn btn-success btn-sm btn-sm-icon" onClick={() => {this.props.undoConfirmPrepped(voter)}}>
             <i className="fa fa-chevron-left" aria-hidden="true"></i>
           </button>
-          <button disabled={!readyToSend} className="btn btn-success btn-sm" onClick={() => {this.props.confirmSent(voter)}}>
+          <button disabled={!readyToSend} className="btn btn-success btn-sm btn-sm-icon" onClick={() => {this.props.confirmSent(voter)}}>
             <span>Sent</span>
             <i className="fa fa-chevron-right ml-2" aria-hidden="true"></i>
           </button>
@@ -68,7 +68,7 @@ class VoterRecord extends Component {
     else {
       voterActions = (
         <div className="btn-group">
-          <button className="btn btn-success btn-sm" onClick={() => {this.props.undoConfirmSent(voter)}}>
+          <button className="btn btn-success btn-sm btn-sm-icon" onClick={() => {this.props.undoConfirmSent(voter)}}>
             <i className="fa fa-chevron-left" aria-hidden="true"></i>
           </button>
         </div>
@@ -162,8 +162,8 @@ export class VoterList extends Component {
     let allPreppedButton;
     if (!this.state.markingAllPrepped) {
       allPreppedButton = (
-        <div className="text-right">
-          <button disabled={this.state.downloadingBundle ? true : false} className="btn btn-light btn-sm mt-1" onClick={() => this.setState({markingAllPrepped: true})}>
+        <div className="text-right mt-2">
+          <button disabled={this.state.downloadingBundle ? true : false} className="btn btn-light btn-sm" onClick={() => this.setState({markingAllPrepped: true})}>
             Finished? Mark all letters as prepared <small><i className="fa fa-chevron-right"></i></small>
           </button>
         </div>
@@ -244,7 +244,7 @@ export class VoterList extends Component {
             <ul className="list-group">
               {toPrep.length < 1 &&
                 <li className="list-group-item disabled text-center py-5 bg-light">
-                  There are no letters to prepare.
+                  You haven’t adopted any voters yet.
                 </li>
               }
               {toPrep.map(voter =>
@@ -264,7 +264,7 @@ export class VoterList extends Component {
             <ul className="list-group">
               {toSend.length < 1 &&
                 <li className="list-group-item disabled text-center py-5 bg-light">
-                  There are no letters to mail.
+                  You haven’t prepared any letters yet.
                 </li>
               }
               {toSend.map(voter =>
@@ -285,7 +285,7 @@ export class VoterList extends Component {
             <ul className="list-group">
               {alreadySent.length < 1 &&
                 <li className="list-group-item disabled text-center py-5 bg-light">
-                  You haven’t sent any letters yet.<br />(Wait until October 30!)
+                  You haven’t mailed any letters yet.<br />(Wait until October 30)
                 </li>
               }
               {alreadySent.map(voter =>

--- a/src/VoterList.js
+++ b/src/VoterList.js
@@ -171,8 +171,8 @@ export class VoterList extends Component {
     }
     else {
       allPreppedButton = (
-        <div className="alert alert-warning ml-3" role="alert">
-          <p>Are you sure?</p>
+        <div className="alert alert-warning mt-2" role="alert">
+          <p>Have all these letters been prepared?<br/><small>(Or will they be?)</small></p>
           <button className="btn btn-success btn-sm mr-2" onClick={this.markAllPrepped}>
             <i className="fa fa-check"></i> Yes!
           </button>
@@ -194,7 +194,7 @@ export class VoterList extends Component {
       if (readyToSend) {
         allSentButton = (
           <button className="btn btn-light btn-sm ml-2" onClick={() => this.setState({markingAllSent: true})}>
-            Mark all letters as sent <small><i className="fa fa-chevron-right"></i></small>
+            Have all these letters been sent <small><i className="fa fa-chevron-right"></i></small>
           </button>
         )
       }
@@ -207,7 +207,7 @@ export class VoterList extends Component {
     else {
       allSentButton = (
         <div className="alert alert-warning ml-3" role="alert">
-          <p>Are you sure?</p>
+          <p>All these letters have been mailed?</p>
           <button className="btn btn-success btn-sm mr-2" onClick={this.markAllSent}>
             <i className="fa fa-check"></i> Yes!
           </button>

--- a/src/VoterList.js
+++ b/src/VoterList.js
@@ -285,7 +285,7 @@ export class VoterList extends Component {
             <ul className="list-group">
               {alreadySent.length < 1 &&
                 <li className="list-group-item disabled text-center py-5 bg-light">
-                  You haven’t mailed any letters yet.<br />(Wait until October 30)
+                  You haven’t mailed any letters yet.<br /><small>(Wait until October 30!)</small>
                 </li>
               }
               {alreadySent.map(voter =>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -139,14 +139,14 @@ li {
   border-radius: 5px;
   line-height: 1;
   font-weight: bold;
-  transition: none; }
+  transition: none;
+  padding: 0.75rem .75rem 1rem; }
 
 .btn-lg {
   padding: 1rem 1rem 1.25rem !important; }
 
 .btn-primary {
-  box-shadow: inset 0 -3px 0 #0043c5;
-  padding: 0.375rem .75rem 0.65rem; }
+  box-shadow: inset 0 -3px 0 #0043c5; }
   .btn-primary:active {
     box-shadow: inset 0 3px 0 #0043c5; }
   .btn-primary:focus {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -135,12 +135,18 @@ li {
   border-top: 8px solid #262D7D !important; }
 
 .btn {
-  border: none;
   border-radius: 5px;
   line-height: 1;
   font-weight: bold;
   transition: none;
   padding: 0.75rem .75rem 1rem; }
+
+.btn-sm {
+  padding: 0.75rem .75rem 1rem; }
+
+.btn-sm-icon {
+  padding: 0.375rem .6rem 0.55rem 0.7rem;
+  border: none; }
 
 .btn-lg {
   padding: 1rem 1rem 1.25rem !important; }
@@ -154,8 +160,7 @@ li {
     background: #1363ff; }
 
 .btn-light {
-  box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.2);
-  padding: 0.375rem .75rem 0.65rem; }
+  box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.2); }
   .btn-light:active {
     box-shadow: inset 0 3px 0 rgba(0, 0, 0, 0.2); }
   .btn-light:focus {

--- a/src/scss/_global.scss
+++ b/src/scss/_global.scss
@@ -138,6 +138,8 @@ li {
   line-height: 1;
   font-weight: bold;
   transition: none;
+  padding: 0.75rem .75rem 1rem;
+
 }
 
 .btn-lg {
@@ -147,7 +149,6 @@ li {
 
 .btn-primary {
   box-shadow: inset 0 -3px 0 darken($vf-blue, 20%);
-  padding: 0.375rem .75rem 0.65rem;
 
   &:active {
     box-shadow: inset 0 3px 0 darken($vf-blue, 20%);

--- a/src/scss/_global.scss
+++ b/src/scss/_global.scss
@@ -133,13 +133,20 @@ li {
 // Buttons
 
 .btn {
-  border: none;
   border-radius: 5px;
   line-height: 1;
   font-weight: bold;
   transition: none;
   padding: 0.75rem .75rem 1rem;
+}
 
+.btn-sm {
+  padding: 0.75rem .75rem 1rem;
+}
+
+.btn-sm-icon {
+  padding: 0.375rem .6rem 0.55rem 0.7rem;
+  border: none;
 }
 
 .btn-lg {
@@ -161,7 +168,6 @@ li {
 
 .btn-light {
   box-shadow: inset 0 -3px 0 rgba(0,0,0,0.2);
-  padding: 0.375rem .75rem 0.65rem;
 
   &:active {
     box-shadow: inset 0 3px 0 rgba(0,0,0,0.2);


### PR DESCRIPTION
A variety of text and UI tweaks to the voter dashboard to attempt to improve clarity. 

State when no voters have been adopted (note text changes to column headers):

![image](https://user-images.githubusercontent.com/1408929/47276711-1f771800-d587-11e8-8b66-9bf21eb75c00.png)

When voters have been adopted (note button text, color and layout changes, meant to emphasize the columns below and de-emphasize adopting more voters):
 
![image](https://user-images.githubusercontent.com/1408929/47276596-3e28df00-d586-11e8-9dca-e779e12a6fa0.png)

When clicking "prepare all": 
![image](https://user-images.githubusercontent.com/1408929/47276667-b2fc1900-d586-11e8-9d82-205d496559c7.png)
