### PR TITLE
Dashboard text improvements

### DIFF
--- a/src/VoterList.js
+++ b/src/VoterList.js
@@ -242,11 +242,18 @@ export class VoterList extends Component {
               {alertContent}
             </div>
             <ul className="list-group">
-              {toPrep.length < 1 &&
+              {toPrep.length < 1 && toSend.length < 1 &&
                 <li className="list-group-item disabled text-center py-5 bg-light">
                   You haven’t adopted any voters yet.
                 </li>
               }
+              
+              {toPrep.length < 1 && toSend.length > 0 &&
+                <li className="list-group-item disabled text-center py-5 bg-light">
+                  You have no more letters to prepare. 
+                </li>
+              }
+                            
               {toPrep.map(voter =>
                 <VoterRecord
                   key={voter.id}

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -2756,6 +2756,8 @@ table.table tr:first-child td {
     min-width: 25px;
     padding-right: 1em;
     text-align: right; }
+  .p-statusBar .p-statusBar_bar.complete {
+    border-radius: 25px; }
   .p-statusBar .p-statusBar_status {
     color: #495057;
     position: absolute;

--- a/src/scss/_districts.scss
+++ b/src/scss/_districts.scss
@@ -17,6 +17,10 @@ $statusBarRadius: $statusBarHeight/2;
     padding-right: 1em;
     text-align: right;
   }
+  
+  .p-statusBar_bar.complete {
+    border-radius: $statusBarRadius;
+  }
   .p-statusBar_status {
     color: $gray-700;
     position: absolute;


### PR DESCRIPTION
Two improvements here:

If the user has already prepared letters, and the "Letters to Print and Prepare" list is empty, change the default list message from "You haven't adopted any voters yet" to "You have no more letters to prepare":

![image](https://user-images.githubusercontent.com/1408929/47449894-ca5b2200-d791-11e8-9515-3892ceed65c9.png)

Also, when viewing a target district detail, change the call-to-action button if the district is full. Here's the "before", or current view of a full district:

![image](https://user-images.githubusercontent.com/1408929/47449953-f4144900-d791-11e8-88d8-a0252ed7c4b6.png)

Here's after this change:

![image](https://user-images.githubusercontent.com/1408929/47449982-042c2880-d792-11e8-9982-3653ea55272f.png)

