### PR TITLE
Fix letter counts in admin voter profile view

### DIFF
--- a/migrations/20180810201533_add_pledge_table.js
+++ b/migrations/20180810201533_add_pledge_table.js
@@ -1,0 +1,24 @@
+'use strict';
+
+exports.up = function(knex, Promise) {
+  return knex.schema
+    .createTable('pledges', function (table) {
+      table.increments();
+      table.integer('voter_id').references('id').inTable('voters');
+      table.enu('type', ['VIEW', 'COMMIT']);
+      table.boolean('real_voter');
+      table.timestamps(false, true);
+      table.index('voter_id');
+    })
+    .table('voters', function(table) {
+      table.integer('pledge_count');
+    });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema
+    .dropTableIfExists('pledges')
+    .table('voters', function (table) {
+      table.dropColumn('pledge_count');
+    });
+};

--- a/migrations/20181024142828_alter_view_bundles.js
+++ b/migrations/20181024142828_alter_view_bundles.js
@@ -26,9 +26,10 @@ exports.up = function(knex, Promise) {
 
 };
 
-exports.down = function(knex, Promise) {
+exports.down = function(knex, Promise) {   
    const createView =
-  `create or replace view ${view} as
+  `drop view ${view};
+   create view ${view} as
    select x.adopter_user_id,
           x.adopted_at,
           extract(epoch from x.adopted_at) as epoch,

--- a/migrations/20181024142828_alter_view_bundles.js
+++ b/migrations/20181024142828_alter_view_bundles.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const view = 'bundles'
+
+exports.up = function(knex, Promise) {
+  const createView =
+  `create or replace view ${view} as
+   select x.adopter_user_id,
+          x.adopted_at,
+          extract(epoch from x.adopted_at) as epoch,
+          x.district_id,
+          x.prepped - x.sent as prepped_count,
+          x.sent as sent_count,
+          x.count - x.prepped - x.sent as unprepped_count
+   from (select   adopted_at, adopter_user_id, district_id,
+                  count(confirmed_prepped_at) as prepped,
+                  count(confirmed_sent_at) as sent,
+                  count(*)
+         from     voters
+         where    adopter_user_id is not null
+         group by adopted_at, adopter_user_id, district_id
+         )
+         as x
+   group by x.adopter_user_id, x.adopted_at, x.district_id, x.prepped, x.sent, x.count;`
+  return knex.raw(createView);
+
+};
+
+exports.down = function(knex, Promise) {
+   const createView =
+  `create or replace view ${view} as
+   select x.adopter_user_id,
+          x.adopted_at,
+          extract(epoch from x.adopted_at) as epoch,
+          x.district_id,
+          sum(x.prepped::int) - sum(x.sent::int) as prepped_count,
+          sum(x.sent::int) as sent_count,
+          sum(x.count) - sum(x.prepped::int) - sum(x.sent::int) as unprepped_count
+   from (select   adopted_at, adopter_user_id, district_id,
+                  confirmed_prepped_at is not null as prepped,
+                  confirmed_sent_at is not null as sent,
+                  count(*)
+         from     voters
+         where    adopter_user_id is not null
+         group by adopted_at, adopter_user_id, district_id, confirmed_prepped_at, confirmed_sent_at)
+         as x
+   group by x.adopter_user_id, x.adopted_at, x.district_id;`
+  return knex.raw(createView);
+};

--- a/migrations/20181024142828_alter_view_bundles.js
+++ b/migrations/20181024142828_alter_view_bundles.js
@@ -4,7 +4,8 @@ const view = 'bundles'
 
 exports.up = function(knex, Promise) {
   const createView =
-  `create or replace view ${view} as
+  `drop view ${view};
+   create or replace view ${view} as
    select x.adopter_user_id,
           x.adopted_at,
           extract(epoch from x.adopted_at) as epoch,

--- a/server/voterService.js
+++ b/server/voterService.js
@@ -12,6 +12,7 @@ const errors = require('./errors');
 const jwt = require('jsonwebtoken');
 
 const allowedVoterBulkCount = [1, 5, 25, 50];
+const pledgeCountThreshold = 200; // Stop recording pledge activity after this number of hits
 let adoptionOrder = 'RANDOM()';
 
 function getVoterById(voterId, callback) {
@@ -95,6 +96,27 @@ function denormalizeVoterCount(districtId) {
     available_voter_count:
       db.raw("(select count(1) from voters where voters.district_id=? and voters.adopter_user_id is null)", districtId)
   });
+}
+
+function recordPledgeActivity({ voterId, realVoter, type, pledgeCount }) {
+  if (pledgeCount > pledgeCountThreshold) {
+    return;
+  } else {
+    return db('pledges')
+      .insert({ voter_id: voterId, type, real_voter: realVoter })
+      .then(() => {
+        return db('voters')
+        .where('id', voterId)
+        // The purpose of this pledge count on the voters table is to 
+        //   prevent someone from overwhelming the database with writes using a single
+        //   hashid.  After the pledge_count exceeds a certain threshold, we'll stop recording
+        //   for that voter
+        .update({
+          pledge_count:
+            db.raw("(select count(1) from pledges where pledges.voter_id=?)", voterId)
+        });
+      });
+  }
 }
 
 function _adoptSomeVoters(adopterId, numVoters, districtId, callback) {
@@ -378,7 +400,7 @@ function voterInfoFromHash(hash) {
   return new Promise((resolve, reject) => {
     let voter;
     db('voters')
-    .select('id', 'district_id')
+    .select('id', 'district_id', 'pledge_count')
     .where('hashid', hash)
     .then((results) => {
       if (results.length === 0) {
@@ -390,6 +412,14 @@ function voterInfoFromHash(hash) {
     })
     .then((district) => {
       resolve({voter, district, shouldRecordPledge: shouldRecordPledge()});
+    })
+    .then(() => {
+      return recordPledgeActivity({
+        voterId: voter.id,
+        pledgeCount: voter.pledge_count,
+        realVoter: shouldRecordPledge(), 
+        type: 'VIEW'
+      });
     })
     .catch(err => {
       reject(err);
@@ -424,25 +454,38 @@ function makePledge(code, callback) {
       callback('already pledged');
       return;
     }
+    let postPledgePromise;
     if (!shouldRecordPledge()) {
+      postPledgePromise = Promise.resolve();
       callback('too soon');
-      return;
-    }
-    // get the pledge row and update it with pledge time
-    db('voters')
-    .where('hashid', code)
-    .update({
-      pledge_made_at: db.fn.now(),
-      updated_at: db.fn.now()
-    })
-    // send an email to the person who wrote the letter telling them a pledge was made
-    .then(getLetterWritingUserFromPledge(code)
-      .then(function(user){
-        emailService.sendEmail('pledge', user, 'One of your unlikely voters pledged to vote!');
+    } else {
+      // get the pledge row and update it with pledge time
+      postPledgePromise = db('voters')
+      .where('hashid', code)
+      .update({
+        pledge_made_at: db.fn.now(),
+        updated_at: db.fn.now()
       })
-    )
-    .then(function() {
-      callback('successful pledge');
+      // send an email to the person who wrote the letter telling them a pledge was made
+      .then(getLetterWritingUserFromPledge(code)
+        .then(function(user){
+          emailService.sendEmail('pledge', user, 'One of your unlikely voters pledged to vote!');
+        })
+      )
+      .then(function() {
+        callback('successful pledge');
+      })
+    }
+
+    postPledgePromise
+    .then(() => {
+      // Record pledge activity
+      recordPledgeActivity({
+        voterId: result[0].id,
+        pledgeCount: result[0].pledge_count,
+        realVoter: shouldRecordPledge(),
+        type: 'COMMIT'
+      });
     })
     .catch(err => {
       console.error(err)

--- a/src/Pledge.js
+++ b/src/Pledge.js
@@ -8,13 +8,17 @@ import { Footer } from './Footer';
 class PledgeForm extends Component {
   constructor(props) {
     super(props);
-    this.state = {value: '', pledgeError: false};
+    this.state = {
+      value: '', 
+      pledgeError: false,
+      placeholderCode: 'A1B2C3D'
+    };
     this.handleChange = this.handleChange.bind(this);
     this.getVoterInfo = this.getVoterInfo.bind(this);
   }
 
   handleChange(event) {
-    this.setState({value: event.target.value});
+    this.setState({value: event.target.value, pledgeError: false});
   }
   getVoterInfo(event) {
     event.preventDefault();
@@ -51,13 +55,16 @@ class PledgeForm extends Component {
             <p className="lead mb-3">
               For more info about the election, enter the code from your letter here...
             </p>
-            <input className="form-control form-control-lg text-center mb-2 w-100" type="text" placeholder="A1B2C3D" value={this.state.value} onChange={this.handleChange} />
+            <input className="form-control form-control-lg text-center mb-2 w-100" type="text" placeholder={this.state.placeholderCode} value={this.state.value} onChange={this.handleChange} />
           </label>
           <input className="btn btn-primary btn-lg w-100" type="submit" value="Submit" />
         </form>
       { this.state.pledgeError &&
         <div className="alert alert-danger mt-3" role="alert">
-          Sorry, we didn’t recognize that code. Please try again!
+          {this.state.value === this.state.placeholderCode ?
+            <div>Whoops, you've entered the sample code!  Please enter the code from <i>your</i> letter.</div> :
+            <div>Sorry, we didn’t recognize that code. Please try again!</div>
+          }
         </div>
       }
       </div>
@@ -100,9 +107,8 @@ class PledgeInfo extends Component {
                 </h2>
                 <p>Will you be voting in the election on Tuesday, November 6?</p>
                 <input className="btn btn-primary btn-lg w-100" type="submit" value="Yes, I'll be Voting!" />
-                <p className="mt-2">We will <strong>anonymously</strong> inform the volunteer who wrote to you that one of their addressees is planning to vote. It will mean a lot to them!</p>
-                { !this.props.shouldRecordPledge && (
-                  <p className="mt-2 small"><i>Note: this page is running in “sandbox” mode, because letters have not yet been sent. It will switch to “active” mode and begin recording pledges on October 30.</i></p>
+                { this.props.shouldRecordPledge && (
+                  <p className="mt-2">We will <strong>anonymously</strong> inform the volunteer who wrote to you that one of their addressees is planning to vote. It will mean a lot to them!</p>
                 ) }
               </div>
             <div className="mt-4">
@@ -193,7 +199,7 @@ class Pledge extends Component {
         }
         { this.state.codeSubmitted && this.state.pledgeStatus !== 'thanks' &&
           (
-            <PledgeInfo 
+            <PledgeInfo
               handlePledgeThanks={this.handlePledgeThanks.bind(this)}
               pledgeStatus={this.state.pledgeStatus}
               voterState={this.state.voterState}


### PR DESCRIPTION
Voter counts in the admin console (under the voter profile view) don't match actual state. For instance, this table (on my local server):

![image](https://user-images.githubusercontent.com/1408929/47453244-448fa480-d79a-11e8-95cc-70d6e434db1f.png)

... doesn't match actual state:

![image](https://user-images.githubusercontent.com/1408929/47453315-68eb8100-d79a-11e8-8dbb-b4479c9cb00f.png)

With this change and `knex migrate:latest`, the voter counts are correct:
![image](https://user-images.githubusercontent.com/1408929/47453069-c03d2180-d799-11e8-8468-c5cb47a8264e.png)
