### PR TITLE
Attempt to improve coversheet language

### DIFF
--- a/templates/coverpage.html
+++ b/templates/coverpage.html
@@ -13,7 +13,7 @@
   <body>
     <div class="cover">
       <h1>Vote Forward Voter List</h1>
-      <p>Thank you for writing letters to help flip Congress blue! Here's some information about the {{voters.length}} voters in this batch. The addresses are also in small print at the bottom of each letter for easy reference.</p>
+      <p>Thank you for writing letters to help flip Congress blue! This packet contains {{total_voters}} letters{{#if multiple_batches}}, and {{voters.length}} names and addresses are listed below{{/if}}. <em>Names and addresses are printed at the bottom of each letter.</em></p>
       <p>Return address(es): your FIRST NAME AND LAST INITIAL, plus:<br>
       </p>
         <ul class="small">

--- a/templates/coverpage.html
+++ b/templates/coverpage.html
@@ -13,7 +13,7 @@
   <body>
     <div class="cover">
       <h1>Vote Forward Voter List</h1>
-      <p>Thank you for writing letters to help flip Congress blue! This packet contains {{total_voters}} letters{{#if multiple_batches}}, and {{voters.length}} names and addresses are listed below{{/if}}. <em>Names and addresses are printed at the bottom of each letter.</em></p>
+      <p>Thank you for writing letters to help flip Congress blue! This packet contains {{total_voters}} letters{{#if multiple_batches}}, {{voters.length}} of which are listed below{{/if}}. <em>Each letter is specific to its recipient. A name and address is printed at the bottom of each page.</em></p>
       <p>Return address(es): your FIRST NAME AND LAST INITIAL, plus:<br>
       </p>
         <ul class="small">


### PR DESCRIPTION
Customers sometimes report confusion with the PDF coversheets, which are spread throughout larger packets of letters, either reporting:

- The cover sheet doesn't have all my voters! (It only has the first twenty)
- Page 2 of my packet is printing in the middle of the PDF! (It's the second cover sheet)
- I have voter letters that aren't on my list! (They're not on the first cover sheet, but are on others)

As a stopgap, this PR changes the language in the cover sheet introduction to clarify how many letters are in the packet and how many are in the first cover sheet:

![image](https://user-images.githubusercontent.com/1408929/47455645-63913500-d7a0-11e8-80fb-dc6675c15ad8.png)
