### PR TITLE
Fix duplicate "logging in with facebook" message

### DIFF
--- a/src/AuthError.js
+++ b/src/AuthError.js
@@ -20,7 +20,7 @@ class AuthError extends Component {
 
       if (duplicateContext.duplicate === 'google-oauth2') {
         duplicateText = "clicking 'Log in with Google'";
-      } else if (duplicateContext.provider === 'facebook') {
+      } else if (duplicateContext.duplicate === 'facebook') {
         duplicateText = "clicking 'Log in with Facebook'";
       } else {
         duplicateText = "providing your email address and password";

--- a/src/AuthError.js
+++ b/src/AuthError.js
@@ -11,17 +11,17 @@ class AuthError extends Component {
       let duplicateText;
 
       if (duplicateContext.provider === 'google-oauth2') {
-        providerText = "clicked 'Sign up with Google' or 'Log in with Google,'";
+        providerText = "clicked ‘Sign up with Google’ or ‘Log in with Google,’";
       } else if (duplicateContext.provider === 'facebook') {
-        providerText = "clicked 'Sign up with Facebook' or 'Log in with Facebook,'";
+        providerText = "clicked ‘Sign up with Facebook’ or ‘Log in with Facebook,’";
       } else {
         providerText = "attempted to sign up with an email address and password,";
       }
 
       if (duplicateContext.duplicate === 'google-oauth2') {
-        duplicateText = "clicking 'Log in with Google'";
+        duplicateText = "clicking ‘Log in with Google’";
       } else if (duplicateContext.duplicate === 'facebook') {
-        duplicateText = "clicking 'Log in with Facebook'";
+        duplicateText = "clicking ‘Log in with Facebook’";
       } else {
         duplicateText = "providing your email address and password";
       }
@@ -33,8 +33,17 @@ class AuthError extends Component {
               <div className="col-sm-4 col-10 mx-auto text-center my-5">
                 <h1>Whoops!</h1>
                 <p>
-                  We detected a problem. It looks like you {providerText} but your email address is already registered in our system under an account you made previously by {duplicateText}. To gain access to your existing account, please return to <a href="/">the homepage of the website</a> and try logging in again by once again {duplicateText} when you reach the login screen.
+                  We detected a problem, but it’s easy to fix. It looks like you {providerText} but your email address is already registered in our system under an account you made previously by {duplicateText}.
                 </p>
+                <p>
+                  To gain access to your existing account, please:
+                </p>
+                <ol>
+                  <li>Return to <a href="/">our home page</a></li>
+                  <li>Click “Log In”</li>
+                  <li><strong>Important:</strong> Click “Not Your Account?” to reset the login system.</li>
+                  <li>Log in by {duplicateText}.</li>
+                </ol>
               </div>
             </div>
           <Footer />


### PR DESCRIPTION
When users log in via Facebook but get the "Whoops!" duplicate message, a typo in the code showed this message, which told them to try logging back in via Facebook:

![image](https://user-images.githubusercontent.com/1408929/47469348-76baf980-d7ce-11e8-9ddb-bec39e50f0cf.png)

Also, when this happens to users and they try to log in again, this is what they see:

![image](https://user-images.githubusercontent.com/1408929/47469954-90117500-d7d1-11e8-9f39-4695f6cb50a0.png)

.. which is totally confusing. Auth0 keeps them logged in via the bogus account. They need to click "Not Your Account?" to log out of Auth0, and then log back in. The wording is changed to reflect that, but I'll open an issue to see if we can make this easier. In the meantime, I've tried to adjust the wording to give more explicit instructions about what needs to happen for them to log in via their original account.