### PR TITLE
Fix 429 errors

### DIFF
--- a/server/rateLimits.js
+++ b/server/rateLimits.js
@@ -5,15 +5,15 @@ var makePledgeRateLimit = new RateLimit({
   delayAfter: 0, // no delay
   delayMs: 0, // no delay
   max: 10, // start blocking after 10 requests
-  message: "Too many pledge attemps made from right now.  Please try again later.",
+  message: "Too many pledge attempts made in short succession.  Please try again later.",
 });
 
 var lookupDistrictRateLimit = new RateLimit({
   windowMs: 60*1000, // 1 minute window
   delayAfter: 0, // no delay
   delayMs: 0, // no delay
-  max: 10, // start blocking after 10 requests
-  message: "Too many district lookup attemps made from right now.  Please try again later.",
+  max: 100, // start blocking after 100 requests
+  message: "Too many district lookup attempts made in short succession.  Please try again later.",
 });
 
 module.exports = {

--- a/src/DistrictPicker.js
+++ b/src/DistrictPicker.js
@@ -84,7 +84,6 @@ export class DistrictPicker extends Component {
       url: `${process.env.REACT_APP_API_URL}/get-districts-with-stats`
       })
       .then(res => {
-        console.log(res.data);
         this.setState({districts: res.data});
       })
       .catch(err => {


### PR DESCRIPTION
Trying to address https://console.cloud.google.com/errors/CLzV0_yNm8y6Og?time=P1D&project=voteforward-198801, and reports that the districts aren't loading properly on the  dashboard. I was getting 429 errors using the website myself in an innocuous fashion, so I think had this tuned too tightly. Loosening, will hopefully resolve it.