### PR TITLE
#236 additional columns for reminder emails

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -762,14 +762,13 @@ router.route('/admin/users')
     let promise;
     if (req.query.count) {
       promise = Promise.all([
-        userService.getUsers({ count: true, preppedLetters: 'NONE'}),
-        userService.getUsers({ count: true, preppedLetters: 'SOME'}),
+        userService.getUsers({ count: true, preppedLetters: 'NOTPREPPED'}),
         userService.getUsers({ count: true, preppedLetters: 'NOTSENT'})
       ])
       .then((results) => {
         res.json(results);
       })
-    } else if (['NONE','SOME', 'NOTSENT'].indexOf(req.query.preppedLetters) >=0) {
+    } else if (['NOTPREPPED', 'NOTSENT'].indexOf(req.query.preppedLetters) >=0) {
       let dupUsers = {};
       promise = userService.findDuplicateUserEmails()
       .then((results) => {
@@ -779,7 +778,22 @@ router.route('/admin/users')
       .then((users) => {
         // add a "dup_user" field to each user record
         users = users.map((user) => {user.dup_user = dupUsers[user.email] ? 't' : 'f'; return user;});
-        const csv = json2csv.parse(users, { fields: ["id", "email", "dup_user", "auth0_id", "full_name", "count"] });
+        const fields = [
+          "id", 
+          "email", 
+          "dup_user", 
+          "qual_state",
+          "zip",
+          "created_at",
+          "auth0_id", 
+          "full_name", 
+          "identity_provider",
+          "adopted_count",
+          "remaining_count",
+          "to_send_count",
+          "prepped_count",
+        ];
+        const csv = json2csv.parse(users, { fields });
         res.header('Access-Control-Expose-Headers', "Filename");
         res.header('Content-Type', "text/csv");
         res.header('Filename', `${req.query.preppedLetters}.csv`);


### PR DESCRIPTION
To send to users with multiple accounts, I figured they'd just receive N number of emails for the number of accounts they have.  The content of the email could say something like "It's possible to log in to Vote Forward multiple different ways, (facebook, google and email).  Each way you log in is treated as a separate account.  This message is only for voters you adopted via the [identity_provider] login.  In order to take care of your [remaining_voters] voters, you must log in via [identity_provider].  You might have logged in another way as well, in which case you'll receive a separate email to log in that way to take care of any additional voters under that login mechanism."